### PR TITLE
Add Nuxt Cypress Example repo to the Examples page

### DIFF
--- a/content/resources/examples.md
+++ b/content/resources/examples.md
@@ -1,1 +1,3 @@
 # Examples
+
+- [Nuxt + Cypress feature testing](https://github.com/hex-digital/nuxt-cypress-example) - Examples of Cypress tests on different Nuxt functionality, including Nuxt auth and more.


### PR DESCRIPTION
While searching around for examples of Cypress testing Nuxt functionality, I couldn't find much content or many examples for Nuxt. 

The https://github.com/hex-digital/nuxt-cypress-example repo is a showcase of examples of Cypress testing features within a Nuxt application. It currently shows visiting pages, DOM testing, submitting a form and testing the store, including login with Nuxt auth.