### PR TITLE
Merge branch 'release/1.0.0' into develop

### DIFF
--- a/.changes/v1.0.0.md
+++ b/.changes/v1.0.0.md
@@ -1,0 +1,12 @@
+## v1.0.0 (2023-02-16)
+
+### Features
+
+- **Package manager**: Yarn v2+.
+- **Static site generator**: VuePress v2.
+- **Site search service**: Algolia.
+- **Site analytic service**: Google Analytics.
+- **Release:** GitHub Actions + Gitflow.
+- **Deployment:** GitHub Pages + Netlify.
+
+Full Changelog: [v1.0.0](https://github.com/ansidev/sample-gitflow-release-workflows/commits/v1.0.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org).
+
+## v1.0.0 (2023-02-16)
+
+### Features
+
+- **Package manager**: Yarn v2+.
+- **Static site generator**: VuePress v2.
+- **Site search service**: Algolia.
+- **Site analytic service**: Google Analytics.
+- **Release:** GitHub Actions + Gitflow.
+- **Deployment:** GitHub Pages + Netlify.
+
+Full Changelog: [v1.0.0](https://github.com/ansidev/sample-gitflow-release-workflows/commits/v1.0.0)

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -6,6 +6,9 @@ env:
   TAG_PREFIX: v
   CHANGES_DIR: .changes
 
+vars:
+  VERSION_FILE: package.json
+
 tasks:
   prepare:
     desc: Install tools
@@ -36,12 +39,6 @@ tasks:
       - git-chglog --output ${CHANGES_DIR}/{{.VERSION_TAG}}.md --next-tag {{.VERSION_TAG}} {{.VERSION_TAG}}
     silent: true
 
-  bump-version:
-    desc: Bump version
-    cmds:
-      - echo {{.CLI_ARGS}} > VERSION
-    silent: true
-
   commit-release:
     desc: Create release commit
     vars:
@@ -49,7 +46,7 @@ tasks:
     cmds:
       - git add ${CHANGES_DIR}
       - git add CHANGELOG.md
-      - git add VERSION
+      - git add {{.VERSION_FILE}}
       - |
         git commit -m "chore(release): {{.VERSION_TAG}}"
     silent: true
@@ -61,7 +58,6 @@ tasks:
     cmds:
       - echo "Releasing version {{.VERSION_TAG}}"
       - task changelog-next -- {{.CLI_ARGS}}
-      - task bump-version -- {{.CLI_ARGS}}
       - changie merge
       - task commit-release -- {{.CLI_ARGS}}
     silent: true


### PR DESCRIPTION
This PR merges the branch 'release/1.0.0' back into the branch 'develop'.

This ensures that the updates on the branch 'release/1.0.0', i.e. CHANGELOG and manifest updates, are also present on the branch 'develop'.
