### PR TITLE
Upgrade VuePress and its plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "@vuepress/plugin-docsearch": "^2.0.0-beta.60",
     "@vuepress/plugin-git": "^2.0.0-beta.60",
-    "@vuepress/plugin-google-analytics": "^2.0.0-beta.48",
+    "@vuepress/plugin-google-analytics": "^2.0.0-beta.60",
     "@vuepress/plugin-pwa": "^2.0.0-beta.48",
     "markdownlint-cli2": "^0.6.0",
     "vuepress": "^2.0.0-beta.60"
@@ -41,6 +41,7 @@
   "resolutions": {
     "@vuepress/plugin-docsearch": "2.0.0-beta.60",
     "@vuepress/plugin-git": "2.0.0-beta.60",
+    "@vuepress/plugin-google-analytics": "2.0.0-beta.60",
     "vuepress": "2.0.0-beta.60"
   },
   "packageManager": "yarn@3.4.1"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test": "yarn lint"
   },
   "devDependencies": {
-    "@vuepress/plugin-docsearch": "^2.0.0-beta.48",
+    "@vuepress/plugin-docsearch": "^2.0.0-beta.60",
     "@vuepress/plugin-git": "^2.0.0-beta.48",
     "@vuepress/plugin-google-analytics": "^2.0.0-beta.48",
     "@vuepress/plugin-pwa": "^2.0.0-beta.48",
@@ -39,6 +39,7 @@
     "vuepress": "^2.0.0-beta.60"
   },
   "resolutions": {
+    "@vuepress/plugin-docsearch": "2.0.0-beta.60",
     "vuepress": "2.0.0-beta.60"
   },
   "packageManager": "yarn@3.4.1"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@vuepress/plugin-docsearch": "^2.0.0-beta.60",
     "@vuepress/plugin-git": "^2.0.0-beta.60",
     "@vuepress/plugin-google-analytics": "^2.0.0-beta.60",
-    "@vuepress/plugin-pwa": "^2.0.0-beta.48",
+    "@vuepress/plugin-pwa": "^2.0.0-beta.60",
     "markdownlint-cli2": "^0.6.0",
     "vuepress": "^2.0.0-beta.60"
   },
@@ -42,6 +42,7 @@
     "@vuepress/plugin-docsearch": "2.0.0-beta.60",
     "@vuepress/plugin-git": "2.0.0-beta.60",
     "@vuepress/plugin-google-analytics": "2.0.0-beta.60",
+    "@vuepress/plugin-pwa": "2.0.0-beta.60",
     "vuepress": "2.0.0-beta.60"
   },
   "packageManager": "yarn@3.4.1"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@vuepress/plugin-docsearch": "^2.0.0-beta.60",
-    "@vuepress/plugin-git": "^2.0.0-beta.48",
+    "@vuepress/plugin-git": "^2.0.0-beta.60",
     "@vuepress/plugin-google-analytics": "^2.0.0-beta.48",
     "@vuepress/plugin-pwa": "^2.0.0-beta.48",
     "markdownlint-cli2": "^0.6.0",
@@ -40,6 +40,7 @@
   },
   "resolutions": {
     "@vuepress/plugin-docsearch": "2.0.0-beta.60",
+    "@vuepress/plugin-git": "2.0.0-beta.60",
     "vuepress": "2.0.0-beta.60"
   },
   "packageManager": "yarn@3.4.1"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,10 @@
     "@vuepress/plugin-google-analytics": "^2.0.0-beta.48",
     "@vuepress/plugin-pwa": "^2.0.0-beta.48",
     "markdownlint-cli2": "^0.6.0",
-    "vuepress": "^2.0.0-beta.48"
+    "vuepress": "^2.0.0-beta.60"
+  },
+  "resolutions": {
+    "vuepress": "2.0.0-beta.60"
   },
   "packageManager": "yarn@3.4.1"
 }

--- a/vuepress.config.ts
+++ b/vuepress.config.ts
@@ -1,7 +1,7 @@
-const { defaultTheme } = require('vuepress')
-const { docsearchPlugin } = require('@vuepress/plugin-docsearch')
-const { googleAnalyticsPlugin } = require('@vuepress/plugin-google-analytics')
-const { pwaPlugin } = require('@vuepress/plugin-pwa')
+import { defaultTheme } from 'vuepress'
+import { docsearchPlugin } from '@vuepress/plugin-docsearch'
+import { googleAnalyticsPlugin } from '@vuepress/plugin-google-analytics'
+import { pwaPlugin } from '@vuepress/plugin-pwa'
 
 const isProd = process.env.NODE_ENV === "production"
 
@@ -62,29 +62,31 @@ module.exports = {
   base: "/",
   theme: defaultTheme({
     repo: "ansidev/awesome-nuxt",
-    editLinks: true,
-    lastUpdated: "Last Updated",
-    sidebar: [{
-      title: "Resources",
-      collapsable: false,
-      children: [
-        "/resources/official-resources",
-        "/resources/community",
-        "/resources/modules",
-        "/resources/tools",
-        "/resources/mention-of-nuxt",
-        "/resources/tutorials",
-        "/resources/blogs",
-        "/resources/books",
-        "/resources/starter-template",
-        "/resources/docker",
-        "/resources/official-examples",
-        "/resources/community-examples",
-        "/resources/open-source-projects-using-nuxt",
-        "/resources/projects-using-nuxt",
-        "/resources/showcase",
-      ],
-    }, ],
+    editLink: true,
+    lastUpdatedText: "Last Updated",
+    sidebar: [
+      {
+        text: "Resources",
+        collapsible: false,
+        children: [
+          "/resources/official-resources",
+          "/resources/community",
+          "/resources/modules",
+          "/resources/tools",
+          "/resources/mention-of-nuxt",
+          "/resources/tutorials",
+          "/resources/blogs",
+          "/resources/books",
+          "/resources/starter-template",
+          "/resources/docker",
+          "/resources/official-examples",
+          "/resources/community-examples",
+          "/resources/open-source-projects-using-nuxt",
+          "/resources/projects-using-nuxt",
+          "/resources/showcase",
+        ],
+      }
+    ],
     themePlugins: {
       // only enable git plugin in production mode
       git: isProd,
@@ -92,12 +94,12 @@ module.exports = {
   }),
   plugins: [
     docsearchPlugin({
-      appId: process.env.DOCSEARCH_APP_ID,
-      apiKey: process.env.DOCSEARCH_API_KEY,
-      indexName: process.env.DOCSEARCH_INDEX_NAME
+      appId: process.env.DOCSEARCH_APP_ID!,
+      apiKey: process.env.DOCSEARCH_API_KEY!,
+      indexName: process.env.DOCSEARCH_INDEX_NAME!
     }),
     googleAnalyticsPlugin({
-      id: process.env.GA_ID
+      id: process.env.GA_ID!
     }),
     pwaPlugin({
       skipWaiting: true

--- a/yarn.lock
+++ b/yarn.lock
@@ -1699,16 +1699,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mdit-vue/plugin-component@npm:^0.9.0":
-  version: 0.9.4
-  resolution: "@mdit-vue/plugin-component@npm:0.9.4"
-  dependencies:
-    "@types/markdown-it": ^12.2.3
-    markdown-it: ^13.0.1
-  checksum: 96db5897bf32dc5280dea91f12545a0a0316a0112eb884c3685168d76b44ca03b5658397cfb12284147eaa3d233b96260fe6e067f48c74f52ca9580575cc19eb
-  languageName: node
-  linkType: hard
-
 "@mdit-vue/plugin-frontmatter@npm:^0.11.1":
   version: 0.11.1
   resolution: "@mdit-vue/plugin-frontmatter@npm:0.11.1"
@@ -1718,18 +1708,6 @@ __metadata:
     gray-matter: ^4.0.3
     markdown-it: ^13.0.1
   checksum: b19f446a710ba7ccff706eeb2385c5f09e0d954648807a0e57fda316abdc96d3d44ba7e55ba7b8e83273ef9faa96400355ba6e1c22088f86535c0544f5d9d87e
-  languageName: node
-  linkType: hard
-
-"@mdit-vue/plugin-frontmatter@npm:^0.9.1":
-  version: 0.9.2
-  resolution: "@mdit-vue/plugin-frontmatter@npm:0.9.2"
-  dependencies:
-    "@mdit-vue/types": 0.9.2
-    "@types/markdown-it": ^12.2.3
-    gray-matter: ^4.0.3
-    markdown-it: ^13.0.1
-  checksum: 8b971b84e229ad7c8dec3a01a63ce9f4dee3e220325fa22f7ea6c9d08731b8261351fedb95d7e00a583c81464e63aa2ab665871542d2c0c14dd992773fab8b55
   languageName: node
   linkType: hard
 
@@ -1745,18 +1723,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mdit-vue/plugin-headers@npm:^0.9.1":
-  version: 0.9.3
-  resolution: "@mdit-vue/plugin-headers@npm:0.9.3"
-  dependencies:
-    "@mdit-vue/shared": 0.9.2
-    "@mdit-vue/types": 0.9.2
-    "@types/markdown-it": ^12.2.3
-    markdown-it: ^13.0.1
-  checksum: bdb654dd7f73d8d3713ec6d149574475757ffb906d99e787b68c58d7939ef2d09e7ee6c46c7eff513db7ac8ca88bf5352244f300e2a9114dd224d900bd553660
-  languageName: node
-  linkType: hard
-
 "@mdit-vue/plugin-sfc@npm:^0.11.1":
   version: 0.11.1
   resolution: "@mdit-vue/plugin-sfc@npm:0.11.1"
@@ -1765,17 +1731,6 @@ __metadata:
     "@types/markdown-it": ^12.2.3
     markdown-it: ^13.0.1
   checksum: 50bc2e2765458b97dde6d4b71b2997ff09f7f89573173cd6622c96c53f670abfdb9e4b9ed65255653a1a4cba8016a0db94dd08ce7b0167040ed632799d315aff
-  languageName: node
-  linkType: hard
-
-"@mdit-vue/plugin-sfc@npm:^0.9.1":
-  version: 0.9.2
-  resolution: "@mdit-vue/plugin-sfc@npm:0.9.2"
-  dependencies:
-    "@mdit-vue/types": 0.9.2
-    "@types/markdown-it": ^12.2.3
-    markdown-it: ^13.0.1
-  checksum: 06de858688d91f1f1f1e9e9b4d822e2a3f1e97e23e4bae138b3893e78a02acdde27dcf00539c50281f38d05192f3bdd7e0f674b4804578ca55d7ebe909c79211
   languageName: node
   linkType: hard
 
@@ -1791,18 +1746,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mdit-vue/plugin-title@npm:^0.9.1":
-  version: 0.9.3
-  resolution: "@mdit-vue/plugin-title@npm:0.9.3"
-  dependencies:
-    "@mdit-vue/shared": 0.9.2
-    "@mdit-vue/types": 0.9.2
-    "@types/markdown-it": ^12.2.3
-    markdown-it: ^13.0.1
-  checksum: bd5ddeb7372e56d3d1129e71124036e5f8c823dc16d32e269d74dc17783dde049387ca849ac187bf96a99f9fb9dc2befaa1e023d92eaac9b130ea19bda43b0d6
-  languageName: node
-  linkType: hard
-
 "@mdit-vue/plugin-toc@npm:^0.11.2":
   version: 0.11.2
   resolution: "@mdit-vue/plugin-toc@npm:0.11.2"
@@ -1812,18 +1755,6 @@ __metadata:
     "@types/markdown-it": ^12.2.3
     markdown-it: ^13.0.1
   checksum: 07379922ea270f57a5c272b690331a6e7459c9ebc3879f9edace361527d6ab965f7fd1d6d6e08b59ce96bca298648877c6b261d6e0a18deb76653ea38397509b
-  languageName: node
-  linkType: hard
-
-"@mdit-vue/plugin-toc@npm:^0.9.1":
-  version: 0.9.2
-  resolution: "@mdit-vue/plugin-toc@npm:0.9.2"
-  dependencies:
-    "@mdit-vue/shared": 0.9.2
-    "@mdit-vue/types": 0.9.2
-    "@types/markdown-it": ^12.2.3
-    markdown-it: ^13.0.1
-  checksum: 1f9e48f8d7a9dbab1a4ce06028fcc4dd40dd9600c7146fd8bf681bae76e72c4d7a2dcebaf085b4728ae7b997313d4e73aeb2980785ad05881767ad0056323442
   languageName: node
   linkType: hard
 
@@ -1838,28 +1769,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mdit-vue/shared@npm:0.9.2, @mdit-vue/shared@npm:^0.9.1":
-  version: 0.9.2
-  resolution: "@mdit-vue/shared@npm:0.9.2"
-  dependencies:
-    "@mdit-vue/types": 0.9.2
-    "@types/markdown-it": ^12.2.3
-    markdown-it: ^13.0.1
-  checksum: e19836b818306b076aecbf9a2799c5ccddf966c4b928363a15e436dbe579205bebfc27c8d065fa7a4dc0eb095a57b161c0599fd5f6d3ba17acb2067b3c48e6a7
-  languageName: node
-  linkType: hard
-
 "@mdit-vue/types@npm:0.11.0, @mdit-vue/types@npm:^0.11.0":
   version: 0.11.0
   resolution: "@mdit-vue/types@npm:0.11.0"
   checksum: 3367608022b4d493e650175828458be377341aff0fce585166c4a5594b001ce6ffdccb687e780b18bf569823576460f1483669febf9820a065992501e011ca1f
-  languageName: node
-  linkType: hard
-
-"@mdit-vue/types@npm:0.9.2, @mdit-vue/types@npm:^0.9.0":
-  version: 0.9.2
-  resolution: "@mdit-vue/types@npm:0.9.2"
-  checksum: c3f21cfc58c9473a5c5d6c536bb3ad6e6db044a10cd1bc917388b5ad6aafe1dbfeedd31e407ea4fd1910fc759ca2a9a0be00048bb67e4e67077ae94fa9edddbb
   languageName: node
   linkType: hard
 
@@ -2149,7 +2062,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vue/devtools-api@npm:^6.2.1, @vue/devtools-api@npm:^6.4.5":
+"@vue/devtools-api@npm:^6.4.5":
   version: 6.5.0
   resolution: "@vue/devtools-api@npm:6.5.0"
   checksum: ec819ef3a426e91d09e9cfefd2827e9ed8ec9d62bb3b3e0674f3da8c7e92a4b879c3b777dc7329172ca6fe2670b62dd5580d23160339208f0f5ae038f2e504ad
@@ -2211,7 +2124,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vue/shared@npm:3.2.47, @vue/shared@npm:^3.2.37, @vue/shared@npm:^3.2.45":
+"@vue/shared@npm:3.2.47, @vue/shared@npm:^3.2.45":
   version: 3.2.47
   resolution: "@vue/shared@npm:3.2.47"
   checksum: 0aa711dc9160fa0e476e6e94eea4e019398adf2211352d0e4a672cfb6b65b104bbd5d234807d1c091107bdc0f5d818d0f12378987eb7861d39be3aa9f6cd6e3e
@@ -2256,18 +2169,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vuepress/client@npm:2.0.0-beta.50-pre.1":
-  version: 2.0.0-beta.50-pre.1
-  resolution: "@vuepress/client@npm:2.0.0-beta.50-pre.1"
-  dependencies:
-    "@vue/devtools-api": ^6.2.1
-    "@vuepress/shared": 2.0.0-beta.50-pre.1
-    vue: ^3.2.37
-    vue-router: ^4.1.3
-  checksum: f561b864b163980a364658865542b9029d3ddb9229ecb583e2672217571970731e325b2464d7f73f20c6db74673ba03b1600d419768c249561d51427848a6b6e
-  languageName: node
-  linkType: hard
-
 "@vuepress/client@npm:2.0.0-beta.60":
   version: 2.0.0-beta.60
   resolution: "@vuepress/client@npm:2.0.0-beta.60"
@@ -2277,19 +2178,6 @@ __metadata:
     vue: ^3.2.45
     vue-router: ^4.1.6
   checksum: 39f6857e8c82750579a57317194973b5fe2024e3beda73a25537a4076a134cabc0b17b5816c9d8fb723c93e0b7c927d2e30d3780815a9cc3fe3bb82d05e0eaf2
-  languageName: node
-  linkType: hard
-
-"@vuepress/core@npm:2.0.0-beta.50-pre.1":
-  version: 2.0.0-beta.50-pre.1
-  resolution: "@vuepress/core@npm:2.0.0-beta.50-pre.1"
-  dependencies:
-    "@vuepress/client": 2.0.0-beta.50-pre.1
-    "@vuepress/markdown": 2.0.0-beta.50-pre.1
-    "@vuepress/shared": 2.0.0-beta.50-pre.1
-    "@vuepress/utils": 2.0.0-beta.50-pre.1
-    vue: ^3.2.37
-  checksum: 3524f51de673d47fc41c210eed67879330d6724eb2f3520f54b7fb155d8bd7dff22be43ca21f40bcdf0503fbf0b72cbbde933cb025176324055438ce6401efaa
   languageName: node
   linkType: hard
 
@@ -2303,30 +2191,6 @@ __metadata:
     "@vuepress/utils": 2.0.0-beta.60
     vue: ^3.2.45
   checksum: 8c9b84c9e250ee88478eb251f083cb4b7de06bdd9eb9c9a6ffbd16b30de909acdef874ffcaacb48d8d9faaa5895ab636564170696104378ad93e21ffbd59836a
-  languageName: node
-  linkType: hard
-
-"@vuepress/markdown@npm:2.0.0-beta.50-pre.1":
-  version: 2.0.0-beta.50-pre.1
-  resolution: "@vuepress/markdown@npm:2.0.0-beta.50-pre.1"
-  dependencies:
-    "@mdit-vue/plugin-component": ^0.9.0
-    "@mdit-vue/plugin-frontmatter": ^0.9.1
-    "@mdit-vue/plugin-headers": ^0.9.1
-    "@mdit-vue/plugin-sfc": ^0.9.1
-    "@mdit-vue/plugin-title": ^0.9.1
-    "@mdit-vue/plugin-toc": ^0.9.1
-    "@mdit-vue/shared": ^0.9.1
-    "@mdit-vue/types": ^0.9.0
-    "@types/markdown-it": ^12.2.3
-    "@types/markdown-it-emoji": ^2.0.2
-    "@vuepress/shared": 2.0.0-beta.50-pre.1
-    "@vuepress/utils": 2.0.0-beta.50-pre.1
-    markdown-it: ^13.0.1
-    markdown-it-anchor: ^8.6.4
-    markdown-it-emoji: ^2.0.2
-    mdurl: ^1.0.1
-  checksum: a79dde1463a51ead9d3a494fecf0cc3361ace007c63888f6879358f3cf7386e4a8a8ce898a6cf36e474912722be11ef4f46973e642f1d49ef5c231592d69c0aa
   languageName: node
   linkType: hard
 
@@ -2497,18 +2361,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vuepress/plugin-pwa@npm:^2.0.0-beta.48":
-  version: 2.0.0-beta.50-pre.1
-  resolution: "@vuepress/plugin-pwa@npm:2.0.0-beta.50-pre.1"
+"@vuepress/plugin-pwa@npm:2.0.0-beta.60":
+  version: 2.0.0-beta.60
+  resolution: "@vuepress/plugin-pwa@npm:2.0.0-beta.60"
   dependencies:
-    "@vuepress/client": 2.0.0-beta.50-pre.1
-    "@vuepress/core": 2.0.0-beta.50-pre.1
-    "@vuepress/utils": 2.0.0-beta.50-pre.1
+    "@vuepress/client": 2.0.0-beta.60
+    "@vuepress/core": 2.0.0-beta.60
+    "@vuepress/utils": 2.0.0-beta.60
     mitt: ^3.0.0
     register-service-worker: ^1.7.2
-    vue: ^3.2.37
+    vue: ^3.2.45
     workbox-build: ^6.5.4
-  checksum: fa7f438c24ebd85a9057906415d19d955e444bcb1ad519638aef5633f3b5c98d5280655539a7bd12d7347378edce7f207c592ed6aa1c77d0ab1ff865af9df072
+  checksum: e1f921db8a6b3de9a14f2118b243c83f9f63476eba84e452bf4f704c44d2b95a200f65f2b4f44da8e1960a8bf128db2c3a312c3cb61915f192927c24bd5d96bb
   languageName: node
   linkType: hard
 
@@ -2523,15 +2387,6 @@ __metadata:
     "@vuepress/utils": 2.0.0-beta.60
     vue: ^3.2.45
   checksum: f52d88bcda717d7f82f17115cf1dc46b4f583eefcf9b3b38c0a2749c7a6911120108ffc81fcf5d99522169d3f854492acaf50a214ff912fb4086d904e00dcf8c
-  languageName: node
-  linkType: hard
-
-"@vuepress/shared@npm:2.0.0-beta.50-pre.1":
-  version: 2.0.0-beta.50-pre.1
-  resolution: "@vuepress/shared@npm:2.0.0-beta.50-pre.1"
-  dependencies:
-    "@vue/shared": ^3.2.37
-  checksum: 92cf594b5ed10c8afcaea43f5ac641be55a74e02c92aad2710472e9f0647366a9b7a045a4fca51d1aceb090fe3172225d272ae91a014984a267e85a48f37a219
   languageName: node
   linkType: hard
 
@@ -2573,25 +2428,6 @@ __metadata:
     sass-loader:
       optional: true
   checksum: d697dd9804e0eeca7f1a66572a0652f9c05a43475867b7ba5ede61480da63d341295d4acacc7be349e71fcd232468e93e5bbe26bd052d98df26c55b91ee4409a
-  languageName: node
-  linkType: hard
-
-"@vuepress/utils@npm:2.0.0-beta.50-pre.1":
-  version: 2.0.0-beta.50-pre.1
-  resolution: "@vuepress/utils@npm:2.0.0-beta.50-pre.1"
-  dependencies:
-    "@types/debug": ^4.1.7
-    "@types/fs-extra": ^9.0.13
-    "@types/hash-sum": ^1.0.0
-    "@vuepress/shared": 2.0.0-beta.50-pre.1
-    chalk: ^5.0.1
-    debug: ^4.3.4
-    fs-extra: ^10.1.0
-    globby: ^13.1.2
-    hash-sum: ^2.0.0
-    ora: ^6.1.2
-    upath: ^2.0.1
-  checksum: c5c35bbc0e10dcc98bc5d87320b25281de2e48d59f0bca1ca93cabdee3271423b7bd4cb3bb3fcc6faecd34134cd6645526961870bbceae91fcc7d4fad8f5dbea
   languageName: node
   linkType: hard
 
@@ -2836,7 +2672,7 @@ __metadata:
     "@vuepress/plugin-docsearch": ^2.0.0-beta.60
     "@vuepress/plugin-git": ^2.0.0-beta.60
     "@vuepress/plugin-google-analytics": ^2.0.0-beta.60
-    "@vuepress/plugin-pwa": ^2.0.0-beta.48
+    "@vuepress/plugin-pwa": ^2.0.0-beta.60
     markdownlint-cli2: ^0.6.0
     vuepress: ^2.0.0-beta.60
   languageName: unknown
@@ -3077,7 +2913,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^5.0.0, chalk@npm:^5.0.1":
+"chalk@npm:^5.0.0":
   version: 5.2.0
   resolution: "chalk@npm:5.2.0"
   checksum: 03d8060277de6cf2fd567dc25fcf770593eb5bb85f460ce443e49255a30ff1242edd0c90a06a03803b0466ff0687a939b41db1757bec987113e83de89a003caa
@@ -3643,17 +3479,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fs-extra@npm:^10.1.0":
-  version: 10.1.0
-  resolution: "fs-extra@npm:10.1.0"
-  dependencies:
-    graceful-fs: ^4.2.0
-    jsonfile: ^6.0.1
-    universalify: ^2.0.0
-  checksum: dc94ab37096f813cc3ca12f0f1b5ad6744dfed9ed21e953d72530d103cea193c2f81584a39e9dee1bea36de5ee66805678c0dddc048e8af1427ac19c00fffc50
-  languageName: node
-  linkType: hard
-
 "fs-extra@npm:^11.1.0":
   version: 11.1.0
   resolution: "fs-extra@npm:11.1.0"
@@ -3839,7 +3664,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"globby@npm:13.1.3, globby@npm:^13.1.2, globby@npm:^13.1.3":
+"globby@npm:13.1.3, globby@npm:^13.1.3":
   version: 13.1.3
   resolution: "globby@npm:13.1.3"
   dependencies:
@@ -4507,7 +4332,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"markdown-it-anchor@npm:^8.6.4, markdown-it-anchor@npm:^8.6.6":
+"markdown-it-anchor@npm:^8.6.6":
   version: 8.6.6
   resolution: "markdown-it-anchor@npm:8.6.6"
   peerDependencies:
@@ -5941,7 +5766,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vue-router@npm:^4.1.3, vue-router@npm:^4.1.6":
+"vue-router@npm:^4.1.6":
   version: 4.1.6
   resolution: "vue-router@npm:4.1.6"
   dependencies:
@@ -5952,7 +5777,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vue@npm:^3.2.37, vue@npm:^3.2.45":
+"vue@npm:^3.2.45":
   version: 3.2.47
   resolution: "vue@npm:3.2.47"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,31 +5,31 @@ __metadata:
   version: 6
   cacheKey: 8
 
-"@algolia/autocomplete-core@npm:1.7.1":
-  version: 1.7.1
-  resolution: "@algolia/autocomplete-core@npm:1.7.1"
+"@algolia/autocomplete-core@npm:1.7.4":
+  version: 1.7.4
+  resolution: "@algolia/autocomplete-core@npm:1.7.4"
   dependencies:
-    "@algolia/autocomplete-shared": 1.7.1
-  checksum: 511176e9c2a9f2e2be62552e48e72dadfcc6638cda4a2990fd3453aed3ce4e7d8ca1bd6a9ccb912430c77734b00a8b836aaad97facc1987157af4ac00f590f4a
+    "@algolia/autocomplete-shared": 1.7.4
+  checksum: cd7c0badec2dd7f32eb1c567e740473df41d0b5cfdc009efc2b44d2c72e30d90a05882ca0616d6dc29326177d5183a7fd9c6189e5eab3abe26936e232ac5f43a
   languageName: node
   linkType: hard
 
-"@algolia/autocomplete-preset-algolia@npm:1.7.1":
-  version: 1.7.1
-  resolution: "@algolia/autocomplete-preset-algolia@npm:1.7.1"
+"@algolia/autocomplete-preset-algolia@npm:1.7.4":
+  version: 1.7.4
+  resolution: "@algolia/autocomplete-preset-algolia@npm:1.7.4"
   dependencies:
-    "@algolia/autocomplete-shared": 1.7.1
+    "@algolia/autocomplete-shared": 1.7.4
   peerDependencies:
-    "@algolia/client-search": ^4.9.1
-    algoliasearch: ^4.9.1
-  checksum: cb031d5ed43f2e10f325f6291cfab851cc5622d96ae8ba1913815ead16b7ce2969b0c51f921d54c47195b2200af8ceecf1c587d2580f842c337f1d8e2f6317c2
+    "@algolia/client-search": ">= 4.9.1 < 6"
+    algoliasearch: ">= 4.9.1 < 6"
+  checksum: 4ea134757d611d1b7489f34b4366d103fb981dde3f75f39762fb71142f23bd024825f7541ab756ead9c87e223184616fd74b7762982054c96927fecd5a6e6e3e
   languageName: node
   linkType: hard
 
-"@algolia/autocomplete-shared@npm:1.7.1":
-  version: 1.7.1
-  resolution: "@algolia/autocomplete-shared@npm:1.7.1"
-  checksum: 0e137f1a470fab9b1bc493284b0be9b83503bda8aa37be9726a8fddf4791dccbd28f9eec399a7c75c1eb3196510dac7be454307fc97fbca2999f3fbc30756c28
+"@algolia/autocomplete-shared@npm:1.7.4":
+  version: 1.7.4
+  resolution: "@algolia/autocomplete-shared@npm:1.7.4"
+  checksum: d304b1e3523ccf36a4a21ef9c116c83360fc1bffc595e888f05c35ab00de293104184dafebd9b9ed8ac5ffa5c416ddd4b1139e9794a253f52863c1ae544c2c9c
   languageName: node
   linkType: hard
 
@@ -1426,36 +1426,43 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@docsearch/css@npm:3.2.0, @docsearch/css@npm:^3.1.1":
-  version: 3.2.0
-  resolution: "@docsearch/css@npm:3.2.0"
-  checksum: fffad2df82d661bca7c51b857601404089d26f7b8f359a9130d9f3b9088e21bedc18d1fb7dd2f8d25f47e2237d47a45bb881a62656c8c53b76a6dd3a7c98de52
+"@docsearch/css@npm:3.3.3, @docsearch/css@npm:^3.3.1":
+  version: 3.3.3
+  resolution: "@docsearch/css@npm:3.3.3"
+  checksum: c3e678dd5e05a962d3e29b4c953632a013af3a352ad99d0e630546409e665684e122265034bca1619d9bd659e42d35c7cc90ee373836fcfb2614aae2057c5dc1
   languageName: node
   linkType: hard
 
-"@docsearch/js@npm:^3.1.1":
-  version: 3.2.0
-  resolution: "@docsearch/js@npm:3.2.0"
+"@docsearch/js@npm:^3.3.1":
+  version: 3.3.3
+  resolution: "@docsearch/js@npm:3.3.3"
   dependencies:
-    "@docsearch/react": 3.2.0
+    "@docsearch/react": 3.3.3
     preact: ^10.0.0
-  checksum: 62d7bba26b62befc5a8d5f518f3eddc6bd1099de219c1c2f8d5d1cd4f461ac8c449b57a369145f5775c5da1106b0f3dce32a06df56e4ba527b2dd7055e644fa7
+  checksum: 445bb7f66f9ca4b385a28fd78bcbac048acd20d925978a1c23cc1ef74022ec4e3ff93d58819eae9a721dc1ac6eed17e40de536ec67ab99b87fff6e4db6b78a96
   languageName: node
   linkType: hard
 
-"@docsearch/react@npm:3.2.0, @docsearch/react@npm:^3.1.1":
-  version: 3.2.0
-  resolution: "@docsearch/react@npm:3.2.0"
+"@docsearch/react@npm:3.3.3, @docsearch/react@npm:^3.3.1":
+  version: 3.3.3
+  resolution: "@docsearch/react@npm:3.3.3"
   dependencies:
-    "@algolia/autocomplete-core": 1.7.1
-    "@algolia/autocomplete-preset-algolia": 1.7.1
-    "@docsearch/css": 3.2.0
+    "@algolia/autocomplete-core": 1.7.4
+    "@algolia/autocomplete-preset-algolia": 1.7.4
+    "@docsearch/css": 3.3.3
     algoliasearch: ^4.0.0
   peerDependencies:
     "@types/react": ">= 16.8.0 < 19.0.0"
     react: ">= 16.8.0 < 19.0.0"
     react-dom: ">= 16.8.0 < 19.0.0"
-  checksum: 219c15259cf652bcaf12e374b00c98733819e0178be921491e22fd05b4bf89ab8c31490fe266fa4fe63fa00d1fe6f58a8229f9be937db7c887841598cd168502
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    react:
+      optional: true
+    react-dom:
+      optional: true
+  checksum: 8a31c175853b61ee80748abc0cebdc33d247483643c4151a430e05d37f159bf59ea08cb69f878cff7787d3ca122b664701575543914d3c3692b448b63d3ad716
   languageName: node
   linkType: hard
 
@@ -1692,13 +1699,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mdit-vue/plugin-component@npm:^0.6.0":
-  version: 0.6.0
-  resolution: "@mdit-vue/plugin-component@npm:0.6.0"
+"@mdit-vue/plugin-component@npm:^0.9.0":
+  version: 0.9.4
+  resolution: "@mdit-vue/plugin-component@npm:0.9.4"
   dependencies:
     "@types/markdown-it": ^12.2.3
     markdown-it: ^13.0.1
-  checksum: cef9e5b3b976531ad63f16f0f86363fd7afff01ff15b68734d1598569241f52b75aeafd1788266275efd96a0faab5b0aa53140cc695df6b655a3681d986e8b05
+  checksum: 96db5897bf32dc5280dea91f12545a0a0316a0112eb884c3685168d76b44ca03b5658397cfb12284147eaa3d233b96260fe6e067f48c74f52ca9580575cc19eb
   languageName: node
   linkType: hard
 
@@ -1714,15 +1721,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mdit-vue/plugin-frontmatter@npm:^0.6.0":
-  version: 0.6.0
-  resolution: "@mdit-vue/plugin-frontmatter@npm:0.6.0"
+"@mdit-vue/plugin-frontmatter@npm:^0.9.1":
+  version: 0.9.2
+  resolution: "@mdit-vue/plugin-frontmatter@npm:0.9.2"
   dependencies:
-    "@mdit-vue/types": 0.6.0
+    "@mdit-vue/types": 0.9.2
     "@types/markdown-it": ^12.2.3
     gray-matter: ^4.0.3
     markdown-it: ^13.0.1
-  checksum: ebe3dc07a93263e7a8eb9657cc8d0227d9c7c3f0f43961ba0dccb7cc8a07402c0f716b35667fda234a8b84080dbfea5e9117b4ac7a5be1a17f41079626189d6c
+  checksum: 8b971b84e229ad7c8dec3a01a63ce9f4dee3e220325fa22f7ea6c9d08731b8261351fedb95d7e00a583c81464e63aa2ab665871542d2c0c14dd992773fab8b55
   languageName: node
   linkType: hard
 
@@ -1738,15 +1745,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mdit-vue/plugin-headers@npm:^0.6.0":
-  version: 0.6.0
-  resolution: "@mdit-vue/plugin-headers@npm:0.6.0"
+"@mdit-vue/plugin-headers@npm:^0.9.1":
+  version: 0.9.3
+  resolution: "@mdit-vue/plugin-headers@npm:0.9.3"
   dependencies:
-    "@mdit-vue/shared": 0.6.0
-    "@mdit-vue/types": 0.6.0
+    "@mdit-vue/shared": 0.9.2
+    "@mdit-vue/types": 0.9.2
     "@types/markdown-it": ^12.2.3
     markdown-it: ^13.0.1
-  checksum: 1d1e5373484a203f78a6a73fb20855da129c5b18dda5272f2619a844c6b2c980821e01ee8689473cd930994f2d2e591c479bbc9b10be5042557e2d9e3e1f4ac3
+  checksum: bdb654dd7f73d8d3713ec6d149574475757ffb906d99e787b68c58d7939ef2d09e7ee6c46c7eff513db7ac8ca88bf5352244f300e2a9114dd224d900bd553660
   languageName: node
   linkType: hard
 
@@ -1761,14 +1768,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mdit-vue/plugin-sfc@npm:^0.6.0":
-  version: 0.6.0
-  resolution: "@mdit-vue/plugin-sfc@npm:0.6.0"
+"@mdit-vue/plugin-sfc@npm:^0.9.1":
+  version: 0.9.2
+  resolution: "@mdit-vue/plugin-sfc@npm:0.9.2"
   dependencies:
-    "@mdit-vue/types": 0.6.0
+    "@mdit-vue/types": 0.9.2
     "@types/markdown-it": ^12.2.3
     markdown-it: ^13.0.1
-  checksum: 942d57471c33be09797fee3865cf055a0c82716c025dffb7c68f724ee02aef4f93ebc7d8d377de1285516a7deb50866a07bb97b5760480e9593480e1bca9f0d9
+  checksum: 06de858688d91f1f1f1e9e9b4d822e2a3f1e97e23e4bae138b3893e78a02acdde27dcf00539c50281f38d05192f3bdd7e0f674b4804578ca55d7ebe909c79211
   languageName: node
   linkType: hard
 
@@ -1784,15 +1791,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mdit-vue/plugin-title@npm:^0.6.0":
-  version: 0.6.0
-  resolution: "@mdit-vue/plugin-title@npm:0.6.0"
+"@mdit-vue/plugin-title@npm:^0.9.1":
+  version: 0.9.3
+  resolution: "@mdit-vue/plugin-title@npm:0.9.3"
   dependencies:
-    "@mdit-vue/shared": 0.6.0
-    "@mdit-vue/types": 0.6.0
+    "@mdit-vue/shared": 0.9.2
+    "@mdit-vue/types": 0.9.2
     "@types/markdown-it": ^12.2.3
     markdown-it: ^13.0.1
-  checksum: d41383081e8662ce6088371336f2e3cf207f76e1678ccb9c1737d571e69b670ed9f7d02749fd0c6e4b77dddd6bf329ff0bef2bcf3cb6fe427f0a7a96b5274b69
+  checksum: bd5ddeb7372e56d3d1129e71124036e5f8c823dc16d32e269d74dc17783dde049387ca849ac187bf96a99f9fb9dc2befaa1e023d92eaac9b130ea19bda43b0d6
   languageName: node
   linkType: hard
 
@@ -1808,15 +1815,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mdit-vue/plugin-toc@npm:^0.6.0":
-  version: 0.6.0
-  resolution: "@mdit-vue/plugin-toc@npm:0.6.0"
+"@mdit-vue/plugin-toc@npm:^0.9.1":
+  version: 0.9.2
+  resolution: "@mdit-vue/plugin-toc@npm:0.9.2"
   dependencies:
-    "@mdit-vue/shared": 0.6.0
-    "@mdit-vue/types": 0.6.0
+    "@mdit-vue/shared": 0.9.2
+    "@mdit-vue/types": 0.9.2
     "@types/markdown-it": ^12.2.3
     markdown-it: ^13.0.1
-  checksum: dc3c1f53c29ce0a36f08c78e2e2e15517f8d1b7400a42334b7e09508ff66ac2dc05e9e2a6ff2331551e9ff3a225dafeea189cf57eecc3ead239e18c1f6468fa2
+  checksum: 1f9e48f8d7a9dbab1a4ce06028fcc4dd40dd9600c7146fd8bf681bae76e72c4d7a2dcebaf085b4728ae7b997313d4e73aeb2980785ad05881767ad0056323442
   languageName: node
   linkType: hard
 
@@ -1831,14 +1838,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mdit-vue/shared@npm:0.6.0, @mdit-vue/shared@npm:^0.6.0":
-  version: 0.6.0
-  resolution: "@mdit-vue/shared@npm:0.6.0"
+"@mdit-vue/shared@npm:0.9.2, @mdit-vue/shared@npm:^0.9.1":
+  version: 0.9.2
+  resolution: "@mdit-vue/shared@npm:0.9.2"
   dependencies:
-    "@mdit-vue/types": 0.6.0
+    "@mdit-vue/types": 0.9.2
     "@types/markdown-it": ^12.2.3
     markdown-it: ^13.0.1
-  checksum: b96a92b21302b89b360219d17dcb5126c13e25fcdc53d76cada7e6814670256e05262857ded6b46119a5da574211ff10ef7edf389460e9841af8150b195f0b5f
+  checksum: e19836b818306b076aecbf9a2799c5ccddf966c4b928363a15e436dbe579205bebfc27c8d065fa7a4dc0eb095a57b161c0599fd5f6d3ba17acb2067b3c48e6a7
   languageName: node
   linkType: hard
 
@@ -1849,10 +1856,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mdit-vue/types@npm:0.6.0, @mdit-vue/types@npm:^0.6.0":
-  version: 0.6.0
-  resolution: "@mdit-vue/types@npm:0.6.0"
-  checksum: 1fe297b8389c6d2e820edf9ec71f3644be5429cec77a25562f7a647410dcb292ed8b53ae84d51acb7249789294ec70d36294d149d2992e7992219fdbc5c33c7c
+"@mdit-vue/types@npm:0.9.2, @mdit-vue/types@npm:^0.9.0":
+  version: 0.9.2
+  resolution: "@mdit-vue/types@npm:0.9.2"
+  checksum: c3f21cfc58c9473a5c5d6c536bb3ad6e6db044a10cd1bc917388b5ad6aafe1dbfeedd31e407ea4fd1910fc759ca2a9a0be00048bb67e4e67077ae94fa9edddbb
   languageName: node
   linkType: hard
 
@@ -2092,18 +2099,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vue/compiler-core@npm:3.2.37":
-  version: 3.2.37
-  resolution: "@vue/compiler-core@npm:3.2.37"
-  dependencies:
-    "@babel/parser": ^7.16.4
-    "@vue/shared": 3.2.37
-    estree-walker: ^2.0.2
-    source-map: ^0.6.1
-  checksum: 5642e20813352f7ed57ef0eec0fb8a075d6485c91548555b435e8163e62a5e03402c26944bfa2486d6cc4c992f2649478f887478bcd23c8ad9036636f2dcff6a
-  languageName: node
-  linkType: hard
-
 "@vue/compiler-core@npm:3.2.47":
   version: 3.2.47
   resolution: "@vue/compiler-core@npm:3.2.47"
@@ -2116,16 +2111,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vue/compiler-dom@npm:3.2.37":
-  version: 3.2.37
-  resolution: "@vue/compiler-dom@npm:3.2.37"
-  dependencies:
-    "@vue/compiler-core": 3.2.37
-    "@vue/shared": 3.2.37
-  checksum: 6cfa9d2ee123339549ba005fa61b2cd5ccf079ba8d8d797f0075e7054c2766744029cb0997341bcb6a51e129ae43489263aa7d8500b262ef7b81c63c2b0c4576
-  languageName: node
-  linkType: hard
-
 "@vue/compiler-dom@npm:3.2.47":
   version: 3.2.47
   resolution: "@vue/compiler-dom@npm:3.2.47"
@@ -2133,24 +2118,6 @@ __metadata:
     "@vue/compiler-core": 3.2.47
     "@vue/shared": 3.2.47
   checksum: 1eced735f865e6df0c2d7fa041f9f27996ff4c0d4baf5fad0f67e65e623215f4394c49bba337b78427c6e71f2cc2db12b19ec6b865b4c057c0a15ccedeb20752
-  languageName: node
-  linkType: hard
-
-"@vue/compiler-sfc@npm:3.2.37":
-  version: 3.2.37
-  resolution: "@vue/compiler-sfc@npm:3.2.37"
-  dependencies:
-    "@babel/parser": ^7.16.4
-    "@vue/compiler-core": 3.2.37
-    "@vue/compiler-dom": 3.2.37
-    "@vue/compiler-ssr": 3.2.37
-    "@vue/reactivity-transform": 3.2.37
-    "@vue/shared": 3.2.37
-    estree-walker: ^2.0.2
-    magic-string: ^0.25.7
-    postcss: ^8.1.10
-    source-map: ^0.6.1
-  checksum: 9f9067d79f40b0016e4063c180f5417e893f820b970ee291050cad8e19d9258f70a128e5de862e484bfb15572d335c8d5881c95e6b6a3032cb1a94829e8694cb
   languageName: node
   linkType: hard
 
@@ -2172,16 +2139,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vue/compiler-ssr@npm:3.2.37":
-  version: 3.2.37
-  resolution: "@vue/compiler-ssr@npm:3.2.37"
-  dependencies:
-    "@vue/compiler-dom": 3.2.37
-    "@vue/shared": 3.2.37
-  checksum: e137462340c220ef7891d0b40f11124e7d5311e760fdb0de1748c046481505aecd5be8ec8f7b25ac6fc26d2393cbcc267f258d2d26742a50cb9abaf828c28839
-  languageName: node
-  linkType: hard
-
 "@vue/compiler-ssr@npm:3.2.47":
   version: 3.2.47
   resolution: "@vue/compiler-ssr@npm:3.2.47"
@@ -2192,30 +2149,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vue/devtools-api@npm:^6.1.4, @vue/devtools-api@npm:^6.2.0":
-  version: 6.2.1
-  resolution: "@vue/devtools-api@npm:6.2.1"
-  checksum: 34765af0be9b0cc7e3def73b2792b1514e3c348852c5a7503fe07d013f0e907af6c27c0a32c0637dd748caf37c075af8e53ca3220433e0bd34b6f3405f358272
-  languageName: node
-  linkType: hard
-
-"@vue/devtools-api@npm:^6.4.5":
+"@vue/devtools-api@npm:^6.2.1, @vue/devtools-api@npm:^6.4.5":
   version: 6.5.0
   resolution: "@vue/devtools-api@npm:6.5.0"
   checksum: ec819ef3a426e91d09e9cfefd2827e9ed8ec9d62bb3b3e0674f3da8c7e92a4b879c3b777dc7329172ca6fe2670b62dd5580d23160339208f0f5ae038f2e504ad
-  languageName: node
-  linkType: hard
-
-"@vue/reactivity-transform@npm:3.2.37":
-  version: 3.2.37
-  resolution: "@vue/reactivity-transform@npm:3.2.37"
-  dependencies:
-    "@babel/parser": ^7.16.4
-    "@vue/compiler-core": 3.2.37
-    "@vue/shared": 3.2.37
-    estree-walker: ^2.0.2
-    magic-string: ^0.25.7
-  checksum: d9e7c353e2bd3a62a9bbb7498ae231f5194428da003672daadb3e7af50c7839e10fb0ac68252852be353138428d1a36f3b8c7815f9c15499d46e7edaf3730c7e
   languageName: node
   linkType: hard
 
@@ -2232,31 +2169,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vue/reactivity@npm:3.2.37":
-  version: 3.2.37
-  resolution: "@vue/reactivity@npm:3.2.37"
-  dependencies:
-    "@vue/shared": 3.2.37
-  checksum: 94e353f8b8a9301cae15c9366f2fec6a163efb7293e9fe5d1da3ed647f1859139b7b321451db56fb5e3141192c0f0755f74ca9c4bcd30ec44372e45def61d69f
-  languageName: node
-  linkType: hard
-
 "@vue/reactivity@npm:3.2.47":
   version: 3.2.47
   resolution: "@vue/reactivity@npm:3.2.47"
   dependencies:
     "@vue/shared": 3.2.47
   checksum: bd61134e4b2f281067e78b23b34d17f1290a0b3fdb0cd7f06424570b4428c899389451a396694144b0af2fc6dbb1459c38e79151119f12c4f818f4c5004b7d16
-  languageName: node
-  linkType: hard
-
-"@vue/runtime-core@npm:3.2.37":
-  version: 3.2.37
-  resolution: "@vue/runtime-core@npm:3.2.37"
-  dependencies:
-    "@vue/reactivity": 3.2.37
-    "@vue/shared": 3.2.37
-  checksum: 8dbf4e1f973335f5089d6b5965c2756a47589009956f883adb47036315a6d5701ef9d23d52456a6272673bc6f0bcee4f096826b5eae3fec65274e24e9f722a9b
   languageName: node
   linkType: hard
 
@@ -2270,17 +2188,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vue/runtime-dom@npm:3.2.37":
-  version: 3.2.37
-  resolution: "@vue/runtime-dom@npm:3.2.37"
-  dependencies:
-    "@vue/runtime-core": 3.2.37
-    "@vue/shared": 3.2.37
-    csstype: ^2.6.8
-  checksum: 36dddfd56161c94a9a483903a570897e1ee46a95126d54f7948bc184d5d333c9f0c1a9c4cee90ddec63baf4ea2e35be9d0d678108427aba907b0adf0800c75a5
-  languageName: node
-  linkType: hard
-
 "@vue/runtime-dom@npm:3.2.47":
   version: 3.2.47
   resolution: "@vue/runtime-dom@npm:3.2.47"
@@ -2289,18 +2196,6 @@ __metadata:
     "@vue/shared": 3.2.47
     csstype: ^2.6.8
   checksum: 8987d7276174120ed346c456752cdb3633c400432ae89a1a866e342c964b7ed2f9e3e09926f2b4b81fe175b1e4fb3935fe3920c113bcc71464ff39b4e50931f5
-  languageName: node
-  linkType: hard
-
-"@vue/server-renderer@npm:3.2.37":
-  version: 3.2.37
-  resolution: "@vue/server-renderer@npm:3.2.37"
-  dependencies:
-    "@vue/compiler-ssr": 3.2.37
-    "@vue/shared": 3.2.37
-  peerDependencies:
-    vue: 3.2.37
-  checksum: 634d43cd21ed902ef3d1d710db2065c4d47402c979914325494f73e2cd37545d809e665c3aace1a02b32c3332a9ad7e772a00159f42e63abb8b73b0fef27a102
   languageName: node
   linkType: hard
 
@@ -2316,14 +2211,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vue/shared@npm:3.2.37, @vue/shared@npm:^3.2.37":
-  version: 3.2.37
-  resolution: "@vue/shared@npm:3.2.37"
-  checksum: 999ab8baeb13de190d07536e7dd0e74ab9354a864d8d903850a2127ae1a2aa2713a9edc0d957620ebf91165d6603d0cd2b0e8ee0db6cbaf8d57a6a0f912af810
-  languageName: node
-  linkType: hard
-
-"@vue/shared@npm:3.2.47, @vue/shared@npm:^3.2.45":
+"@vue/shared@npm:3.2.47, @vue/shared@npm:^3.2.37, @vue/shared@npm:^3.2.45":
   version: 3.2.47
   resolution: "@vue/shared@npm:3.2.47"
   checksum: 0aa711dc9160fa0e476e6e94eea4e019398adf2211352d0e4a672cfb6b65b104bbd5d234807d1c091107bdc0f5d818d0f12378987eb7861d39be3aa9f6cd6e3e
@@ -2368,15 +2256,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vuepress/client@npm:2.0.0-beta.49":
-  version: 2.0.0-beta.49
-  resolution: "@vuepress/client@npm:2.0.0-beta.49"
+"@vuepress/client@npm:2.0.0-beta.50-pre.1":
+  version: 2.0.0-beta.50-pre.1
+  resolution: "@vuepress/client@npm:2.0.0-beta.50-pre.1"
   dependencies:
-    "@vue/devtools-api": ^6.2.0
-    "@vuepress/shared": 2.0.0-beta.49
+    "@vue/devtools-api": ^6.2.1
+    "@vuepress/shared": 2.0.0-beta.50-pre.1
     vue: ^3.2.37
-    vue-router: ^4.1.2
-  checksum: 2086bde97b12db96c739a932108c6e96592cf51107bb581d3d91e1bfd72554186a50eaff4bcabbec74b52b96a127f04ec5b809a4e226eb0511f21fe7dc2b7040
+    vue-router: ^4.1.3
+  checksum: f561b864b163980a364658865542b9029d3ddb9229ecb583e2672217571970731e325b2464d7f73f20c6db74673ba03b1600d419768c249561d51427848a6b6e
   languageName: node
   linkType: hard
 
@@ -2392,16 +2280,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vuepress/core@npm:2.0.0-beta.49":
-  version: 2.0.0-beta.49
-  resolution: "@vuepress/core@npm:2.0.0-beta.49"
+"@vuepress/core@npm:2.0.0-beta.50-pre.1":
+  version: 2.0.0-beta.50-pre.1
+  resolution: "@vuepress/core@npm:2.0.0-beta.50-pre.1"
   dependencies:
-    "@vuepress/client": 2.0.0-beta.49
-    "@vuepress/markdown": 2.0.0-beta.49
-    "@vuepress/shared": 2.0.0-beta.49
-    "@vuepress/utils": 2.0.0-beta.49
+    "@vuepress/client": 2.0.0-beta.50-pre.1
+    "@vuepress/markdown": 2.0.0-beta.50-pre.1
+    "@vuepress/shared": 2.0.0-beta.50-pre.1
+    "@vuepress/utils": 2.0.0-beta.50-pre.1
     vue: ^3.2.37
-  checksum: 504ad06d932ba8258fa230c4247ae55d2ca423353da910ab38a04f8dc242acb683096d57f3777445aa9b1a70ca8a4c7499e56a54a27a0637918a91c2b09389aa
+  checksum: 3524f51de673d47fc41c210eed67879330d6724eb2f3520f54b7fb155d8bd7dff22be43ca21f40bcdf0503fbf0b72cbbde933cb025176324055438ce6401efaa
   languageName: node
   linkType: hard
 
@@ -2418,27 +2306,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vuepress/markdown@npm:2.0.0-beta.49":
-  version: 2.0.0-beta.49
-  resolution: "@vuepress/markdown@npm:2.0.0-beta.49"
+"@vuepress/markdown@npm:2.0.0-beta.50-pre.1":
+  version: 2.0.0-beta.50-pre.1
+  resolution: "@vuepress/markdown@npm:2.0.0-beta.50-pre.1"
   dependencies:
-    "@mdit-vue/plugin-component": ^0.6.0
-    "@mdit-vue/plugin-frontmatter": ^0.6.0
-    "@mdit-vue/plugin-headers": ^0.6.0
-    "@mdit-vue/plugin-sfc": ^0.6.0
-    "@mdit-vue/plugin-title": ^0.6.0
-    "@mdit-vue/plugin-toc": ^0.6.0
-    "@mdit-vue/shared": ^0.6.0
-    "@mdit-vue/types": ^0.6.0
+    "@mdit-vue/plugin-component": ^0.9.0
+    "@mdit-vue/plugin-frontmatter": ^0.9.1
+    "@mdit-vue/plugin-headers": ^0.9.1
+    "@mdit-vue/plugin-sfc": ^0.9.1
+    "@mdit-vue/plugin-title": ^0.9.1
+    "@mdit-vue/plugin-toc": ^0.9.1
+    "@mdit-vue/shared": ^0.9.1
+    "@mdit-vue/types": ^0.9.0
     "@types/markdown-it": ^12.2.3
     "@types/markdown-it-emoji": ^2.0.2
-    "@vuepress/shared": 2.0.0-beta.49
-    "@vuepress/utils": 2.0.0-beta.49
+    "@vuepress/shared": 2.0.0-beta.50-pre.1
+    "@vuepress/utils": 2.0.0-beta.50-pre.1
     markdown-it: ^13.0.1
     markdown-it-anchor: ^8.6.4
     markdown-it-emoji: ^2.0.2
     mdurl: ^1.0.1
-  checksum: a6ee6e999ad37665ed44b672bae3595f819ebf739b6ac80fe7869295c253dbc589b920833fadc4835976865385972fdf61732358dcc3b8a398195059bb8ed8c9
+  checksum: a79dde1463a51ead9d3a494fecf0cc3361ace007c63888f6879358f3cf7386e4a8a8ce898a6cf36e474912722be11ef4f46973e642f1d49ef5c231592d69c0aa
   languageName: node
   linkType: hard
 
@@ -2508,21 +2396,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vuepress/plugin-docsearch@npm:^2.0.0-beta.48":
-  version: 2.0.0-beta.49
-  resolution: "@vuepress/plugin-docsearch@npm:2.0.0-beta.49"
+"@vuepress/plugin-docsearch@npm:2.0.0-beta.60":
+  version: 2.0.0-beta.60
+  resolution: "@vuepress/plugin-docsearch@npm:2.0.0-beta.60"
   dependencies:
-    "@docsearch/css": ^3.1.1
-    "@docsearch/js": ^3.1.1
-    "@docsearch/react": ^3.1.1
-    "@vuepress/client": 2.0.0-beta.49
-    "@vuepress/core": 2.0.0-beta.49
-    "@vuepress/shared": 2.0.0-beta.49
-    "@vuepress/utils": 2.0.0-beta.49
+    "@docsearch/css": ^3.3.1
+    "@docsearch/js": ^3.3.1
+    "@docsearch/react": ^3.3.1
+    "@vuepress/client": 2.0.0-beta.60
+    "@vuepress/core": 2.0.0-beta.60
+    "@vuepress/shared": 2.0.0-beta.60
+    "@vuepress/utils": 2.0.0-beta.60
     ts-debounce: ^4.0.0
-    vue: ^3.2.37
-    vue-router: ^4.1.2
-  checksum: 01c07a1b421aff2c4070400844cc4e1d6df5fc054d70244ec1cb22a3bb19597e18242ea5e5c721e826dc53adcfc6fbc2139efba23c3152b2dba814e8c2b289e3
+    vue: ^3.2.45
+    vue-router: ^4.1.6
+  checksum: 57efee84299fa776e9ffd25ab274d068fe85f3423ef149c57da807509eec15bf4d5b321a1bb42c7d7d489aca32bedb517a8e3d4a98cfc599de0784a1225ac0d5
   languageName: node
   linkType: hard
 
@@ -2552,24 +2440,24 @@ __metadata:
   linkType: hard
 
 "@vuepress/plugin-git@npm:^2.0.0-beta.48":
-  version: 2.0.0-beta.49
-  resolution: "@vuepress/plugin-git@npm:2.0.0-beta.49"
+  version: 2.0.0-beta.50-pre.1
+  resolution: "@vuepress/plugin-git@npm:2.0.0-beta.50-pre.1"
   dependencies:
-    "@vuepress/core": 2.0.0-beta.49
-    "@vuepress/utils": 2.0.0-beta.49
-    execa: ^5.1.1
-  checksum: 24073cba3f9bb615c6f31641816da6bcec875daa0dec605c66c291df141d8414ff856f47bcf26b125192a890da82f7024ebba35bb68a35f07fd3158cbd5a1ccc
+    "@vuepress/core": 2.0.0-beta.50-pre.1
+    "@vuepress/utils": 2.0.0-beta.50-pre.1
+    execa: ^6.1.0
+  checksum: 4021a699b0da24c189d620abb9038d608c3e2cd75e88f1d686ac5417c42ed07afda98da65980662e9d28270fcc1af2db46e5bef5c902d6e95fce3c6d85455a50
   languageName: node
   linkType: hard
 
 "@vuepress/plugin-google-analytics@npm:^2.0.0-beta.48":
-  version: 2.0.0-beta.49
-  resolution: "@vuepress/plugin-google-analytics@npm:2.0.0-beta.49"
+  version: 2.0.0-beta.50-pre.1
+  resolution: "@vuepress/plugin-google-analytics@npm:2.0.0-beta.50-pre.1"
   dependencies:
-    "@vuepress/client": 2.0.0-beta.49
-    "@vuepress/core": 2.0.0-beta.49
-    "@vuepress/utils": 2.0.0-beta.49
-  checksum: d1e0123327f5323ace98d1dd6137381ec53564c890517cfbaea0ddee05510523c7ab74c58de9c1f001eabf5605126378b16ae39c4aa4a7832c7d5700673cfb01
+    "@vuepress/client": 2.0.0-beta.50-pre.1
+    "@vuepress/core": 2.0.0-beta.50-pre.1
+    "@vuepress/utils": 2.0.0-beta.50-pre.1
+  checksum: 65fc67fa5b3a27e8a198c592d272c773700955281a3fa78d9a711876dc56a2920186b005c594663a474c18fcf3a97728e3e4a2870ae08df713a96c09c2ba5022
   languageName: node
   linkType: hard
 
@@ -2621,17 +2509,17 @@ __metadata:
   linkType: hard
 
 "@vuepress/plugin-pwa@npm:^2.0.0-beta.48":
-  version: 2.0.0-beta.49
-  resolution: "@vuepress/plugin-pwa@npm:2.0.0-beta.49"
+  version: 2.0.0-beta.50-pre.1
+  resolution: "@vuepress/plugin-pwa@npm:2.0.0-beta.50-pre.1"
   dependencies:
-    "@vuepress/client": 2.0.0-beta.49
-    "@vuepress/core": 2.0.0-beta.49
-    "@vuepress/utils": 2.0.0-beta.49
+    "@vuepress/client": 2.0.0-beta.50-pre.1
+    "@vuepress/core": 2.0.0-beta.50-pre.1
+    "@vuepress/utils": 2.0.0-beta.50-pre.1
     mitt: ^3.0.0
     register-service-worker: ^1.7.2
     vue: ^3.2.37
-    workbox-build: ^6.5.3
-  checksum: 50c9cba216e49b8dac88886619877da2bce415e54243ebb4f72a9b670163aa641e53935ce80bbd7a6c6cde5c9e54cc392df4c94df2c73120b46d13c9a75f362c
+    workbox-build: ^6.5.4
+  checksum: fa7f438c24ebd85a9057906415d19d955e444bcb1ad519638aef5633f3b5c98d5280655539a7bd12d7347378edce7f207c592ed6aa1c77d0ab1ff865af9df072
   languageName: node
   linkType: hard
 
@@ -2649,12 +2537,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vuepress/shared@npm:2.0.0-beta.49":
-  version: 2.0.0-beta.49
-  resolution: "@vuepress/shared@npm:2.0.0-beta.49"
+"@vuepress/shared@npm:2.0.0-beta.50-pre.1":
+  version: 2.0.0-beta.50-pre.1
+  resolution: "@vuepress/shared@npm:2.0.0-beta.50-pre.1"
   dependencies:
     "@vue/shared": ^3.2.37
-  checksum: 04475f5e3e21451e9366d91cafb05db586ea330aecbe862c73c9a5fc6e27944428b9df11ce20a0fd6d8444a87caa4825473be7b9de8911b0dba9ee534254d807
+  checksum: 92cf594b5ed10c8afcaea43f5ac641be55a74e02c92aad2710472e9f0647366a9b7a045a4fca51d1aceb090fe3172225d272ae91a014984a267e85a48f37a219
   languageName: node
   linkType: hard
 
@@ -2699,21 +2587,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vuepress/utils@npm:2.0.0-beta.49":
-  version: 2.0.0-beta.49
-  resolution: "@vuepress/utils@npm:2.0.0-beta.49"
+"@vuepress/utils@npm:2.0.0-beta.50-pre.1":
+  version: 2.0.0-beta.50-pre.1
+  resolution: "@vuepress/utils@npm:2.0.0-beta.50-pre.1"
   dependencies:
     "@types/debug": ^4.1.7
     "@types/fs-extra": ^9.0.13
-    "@vuepress/shared": 2.0.0-beta.49
-    chalk: ^4.1.2
+    "@types/hash-sum": ^1.0.0
+    "@vuepress/shared": 2.0.0-beta.50-pre.1
+    chalk: ^5.0.1
     debug: ^4.3.4
     fs-extra: ^10.1.0
-    globby: ^11.0.4
+    globby: ^13.1.2
     hash-sum: ^2.0.0
-    ora: ^5.4.1
+    ora: ^6.1.2
     upath: ^2.0.1
-  checksum: 528a9bce683ae4b78bd93cb5ba0c6b5809fb0aab3b681beb1589adce79b67ebc05720b17d0e5bc04d3f1b60dfa92700144327370a3098f1bcae21764d05b2efb
+  checksum: c5c35bbc0e10dcc98bc5d87320b25281de2e48d59f0bca1ca93cabdee3271423b7bd4cb3bb3fcc6faecd34134cd6645526961870bbceae91fcc7d4fad8f5dbea
   languageName: node
   linkType: hard
 
@@ -2919,13 +2808,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"array-union@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "array-union@npm:2.1.0"
-  checksum: 5bee12395cba82da674931df6d0fea23c4aa4660cb3b338ced9f828782a65caa232573e6bf3968f23e0c5eb301764a382cef2f128b170a9dc59de0e36c39f98d
-  languageName: node
-  linkType: hard
-
 "async@npm:^3.2.3":
   version: 3.2.4
   resolution: "async@npm:3.2.4"
@@ -2962,7 +2844,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "awesome-nuxt@workspace:."
   dependencies:
-    "@vuepress/plugin-docsearch": ^2.0.0-beta.48
+    "@vuepress/plugin-docsearch": ^2.0.0-beta.60
     "@vuepress/plugin-git": ^2.0.0-beta.48
     "@vuepress/plugin-google-analytics": ^2.0.0-beta.48
     "@vuepress/plugin-pwa": ^2.0.0-beta.48
@@ -3037,17 +2919,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bl@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "bl@npm:4.1.0"
-  dependencies:
-    buffer: ^5.5.0
-    inherits: ^2.0.4
-    readable-stream: ^3.4.0
-  checksum: 9e8521fa7e83aa9427c6f8ccdcba6e8167ef30cc9a22df26effcc5ab682ef91d2cbc23a239f945d099289e4bbcfae7a192e9c28c84c6202e710a0dfec3722662
-  languageName: node
-  linkType: hard
-
 "bl@npm:^5.0.0":
   version: 5.1.0
   resolution: "bl@npm:5.1.0"
@@ -3119,16 +2990,6 @@ __metadata:
   version: 1.1.2
   resolution: "buffer-from@npm:1.1.2"
   checksum: 0448524a562b37d4d7ed9efd91685a5b77a50672c556ea254ac9a6d30e3403a517d8981f10e565db24e8339413b43c97ca2951f10e399c6125a0d8911f5679bb
-  languageName: node
-  linkType: hard
-
-"buffer@npm:^5.5.0":
-  version: 5.7.1
-  resolution: "buffer@npm:5.7.1"
-  dependencies:
-    base64-js: ^1.3.1
-    ieee754: ^1.1.13
-  checksum: e2cf8429e1c4c7b8cbd30834ac09bd61da46ce35f5c22a78e6c2f04497d6d25541b16881e30a019c6fd3154150650ccee27a308eff3e26229d788bbdeb08ab84
   languageName: node
   linkType: hard
 
@@ -3217,7 +3078,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^4.0.2, chalk@npm:^4.1.0, chalk@npm:^4.1.2":
+"chalk@npm:^4.0.2":
   version: 4.1.2
   resolution: "chalk@npm:4.1.2"
   dependencies:
@@ -3227,7 +3088,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^5.0.0":
+"chalk@npm:^5.0.0, chalk@npm:^5.0.1":
   version: 5.2.0
   resolution: "chalk@npm:5.2.0"
   checksum: 03d8060277de6cf2fd567dc25fcf770593eb5bb85f460ce443e49255a30ff1242edd0c90a06a03803b0466ff0687a939b41db1757bec987113e83de89a003caa
@@ -3267,15 +3128,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cli-cursor@npm:^3.1.0":
-  version: 3.1.0
-  resolution: "cli-cursor@npm:3.1.0"
-  dependencies:
-    restore-cursor: ^3.1.0
-  checksum: 2692784c6cd2fd85cfdbd11f53aea73a463a6d64a77c3e098b2b4697a20443f430c220629e1ca3b195ea5ac4a97a74c2ee411f3807abf6df2b66211fec0c0a29
-  languageName: node
-  linkType: hard
-
 "cli-cursor@npm:^4.0.0":
   version: 4.0.0
   resolution: "cli-cursor@npm:4.0.0"
@@ -3285,7 +3137,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cli-spinners@npm:^2.5.0, cli-spinners@npm:^2.6.1":
+"cli-spinners@npm:^2.6.1":
   version: 2.7.0
   resolution: "cli-spinners@npm:2.7.0"
   checksum: a9afaf73f58d1f951fb23742f503631b3cf513f43f4c7acb1b640100eb76bfa16efbcd1994d149ffc6603a6d75dd3d4a516a76f125f90dce437de9b16fd0ee6f
@@ -3715,23 +3567,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"execa@npm:^5.1.1":
-  version: 5.1.1
-  resolution: "execa@npm:5.1.1"
-  dependencies:
-    cross-spawn: ^7.0.3
-    get-stream: ^6.0.0
-    human-signals: ^2.1.0
-    is-stream: ^2.0.0
-    merge-stream: ^2.0.0
-    npm-run-path: ^4.0.1
-    onetime: ^5.1.2
-    signal-exit: ^3.0.3
-    strip-final-newline: ^2.0.0
-  checksum: fba9022c8c8c15ed862847e94c252b3d946036d7547af310e344a527e59021fd8b6bb0723883ea87044dc4f0201f949046993124a42ccb0855cae5bf8c786343
-  languageName: node
-  linkType: hard
-
 "execa@npm:^6.1.0":
   version: 6.1.0
   resolution: "execa@npm:6.1.0"
@@ -3775,19 +3610,6 @@ __metadata:
     merge2: ^1.3.0
     micromatch: ^4.0.4
   checksum: 0b1990f6ce831c7e28c4d505edcdaad8e27e88ab9fa65eedadb730438cfc7cde4910d6c975d6b7b8dc8a73da4773702ebcfcd6e3518e73938bb1383badfe01c2
-  languageName: node
-  linkType: hard
-
-"fast-glob@npm:^3.2.9":
-  version: 3.2.11
-  resolution: "fast-glob@npm:3.2.11"
-  dependencies:
-    "@nodelib/fs.stat": ^2.0.2
-    "@nodelib/fs.walk": ^1.2.3
-    glob-parent: ^5.1.2
-    merge2: ^1.3.0
-    micromatch: ^4.0.4
-  checksum: f473105324a7780a20c06de842e15ddbb41d3cb7e71d1e4fe6e8373204f22245d54f5ab9e2061e6a1c613047345954d29b022e0e76f5c28b1df9858179a0e6d7
   languageName: node
   linkType: hard
 
@@ -3968,7 +3790,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-stream@npm:^6.0.0, get-stream@npm:^6.0.1":
+"get-stream@npm:^6.0.1":
   version: 6.0.1
   resolution: "get-stream@npm:6.0.1"
   checksum: e04ecece32c92eebf5b8c940f51468cd53554dcbb0ea725b2748be583c9523d00128137966afce410b9b051eb2ef16d657cd2b120ca8edafcf5a65e81af63cad
@@ -4028,7 +3850,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"globby@npm:13.1.3, globby@npm:^13.1.3":
+"globby@npm:13.1.3, globby@npm:^13.1.2, globby@npm:^13.1.3":
   version: 13.1.3
   resolution: "globby@npm:13.1.3"
   dependencies:
@@ -4038,20 +3860,6 @@ __metadata:
     merge2: ^1.4.1
     slash: ^4.0.0
   checksum: 93f06e02002cdf368f7e3d55bd59e7b00784c7cc8fe92c7ee5082cc7171ff6109fda45e1c97a80bb48bc811dedaf7843c7c9186f5f84bde4883ab630e13c43df
-  languageName: node
-  linkType: hard
-
-"globby@npm:^11.0.4":
-  version: 11.1.0
-  resolution: "globby@npm:11.1.0"
-  dependencies:
-    array-union: ^2.1.0
-    dir-glob: ^3.0.1
-    fast-glob: ^3.2.9
-    ignore: ^5.2.0
-    merge2: ^1.4.1
-    slash: ^3.0.0
-  checksum: b4be8885e0cfa018fc783792942d53926c35c50b3aefd3fdcfb9d22c627639dc26bd2327a40a0b74b074100ce95bb7187bfeae2f236856aa3de183af7a02aea6
   languageName: node
   linkType: hard
 
@@ -4171,13 +3979,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"human-signals@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "human-signals@npm:2.1.0"
-  checksum: b87fd89fce72391625271454e70f67fe405277415b48bcc0117ca73d31fa23a4241787afdc8d67f5a116cf37258c052f59ea82daffa72364d61351423848e3b8
-  languageName: node
-  linkType: hard
-
 "human-signals@npm:^3.0.1":
   version: 3.0.1
   resolution: "human-signals@npm:3.0.1"
@@ -4210,7 +4011,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ieee754@npm:^1.1.13, ieee754@npm:^1.2.1":
+"ieee754@npm:^1.2.1":
   version: 1.2.1
   resolution: "ieee754@npm:1.2.1"
   checksum: 5144c0c9815e54ada181d80a0b810221a253562422e7c6c3a60b1901154184f49326ec239d618c416c1c5945a2e197107aee8d986a3dd836b53dffefd99b5e7e
@@ -4370,13 +4171,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-interactive@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "is-interactive@npm:1.0.0"
-  checksum: 824808776e2d468b2916cdd6c16acacebce060d844c35ca6d82267da692e92c3a16fdba624c50b54a63f38bdc4016055b6f443ce57d7147240de4f8cdabaf6f9
-  languageName: node
-  linkType: hard
-
 "is-interactive@npm:^2.0.0":
   version: 2.0.0
   resolution: "is-interactive@npm:2.0.0"
@@ -4483,13 +4277,6 @@ __metadata:
   dependencies:
     has-symbols: ^1.0.2
   checksum: 92805812ef590738d9de49d677cd17dfd486794773fb6fa0032d16452af46e9b91bb43ffe82c983570f015b37136f4b53b28b8523bfb10b0ece7a66c31a54510
-  languageName: node
-  linkType: hard
-
-"is-unicode-supported@npm:^0.1.0":
-  version: 0.1.0
-  resolution: "is-unicode-supported@npm:0.1.0"
-  checksum: a2aab86ee7712f5c2f999180daaba5f361bdad1efadc9610ff5b8ab5495b86e4f627839d085c6530363c6d6d4ecbde340fb8e54bdb83da4ba8e0865ed5513c52
   languageName: node
   linkType: hard
 
@@ -4672,16 +4459,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"log-symbols@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "log-symbols@npm:4.1.0"
-  dependencies:
-    chalk: ^4.1.0
-    is-unicode-supported: ^0.1.0
-  checksum: fce1497b3135a0198803f9f07464165e9eb83ed02ceb2273930a6f8a508951178d8cf4f0378e9d28300a2ed2bc49050995d2bd5f53ab716bb15ac84d58c6ef74
-  languageName: node
-  linkType: hard
-
 "log-symbols@npm:^5.1.0":
   version: 5.1.0
   resolution: "log-symbols@npm:5.1.0"
@@ -4741,17 +4518,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"markdown-it-anchor@npm:^8.6.4":
-  version: 8.6.4
-  resolution: "markdown-it-anchor@npm:8.6.4"
-  peerDependencies:
-    "@types/markdown-it": "*"
-    markdown-it: "*"
-  checksum: bde310d0202450a228662921df9d9c2e95b3c5762512e8eed1d472fcc812fb20e6b4e98480cda88c8b56b0baf34ac70d6bf8404309c5a2321ebe62da43cd6fe6
-  languageName: node
-  linkType: hard
-
-"markdown-it-anchor@npm:^8.6.6":
+"markdown-it-anchor@npm:^8.6.4, markdown-it-anchor@npm:^8.6.6":
   version: 8.6.6
   resolution: "markdown-it-anchor@npm:8.6.6"
   peerDependencies:
@@ -5071,15 +4838,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"npm-run-path@npm:^4.0.1":
-  version: 4.0.1
-  resolution: "npm-run-path@npm:4.0.1"
-  dependencies:
-    path-key: ^3.0.0
-  checksum: 5374c0cea4b0bbfdfae62da7bbdf1e1558d338335f4cacf2515c282ff358ff27b2ecb91ffa5330a8b14390ac66a1e146e10700440c1ab868208430f56b5f4d23
-  languageName: node
-  linkType: hard
-
 "npm-run-path@npm:^5.1.0":
   version: 5.1.0
   resolution: "npm-run-path@npm:5.1.0"
@@ -5136,7 +4894,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"onetime@npm:^5.1.0, onetime@npm:^5.1.2":
+"onetime@npm:^5.1.0":
   version: 5.1.2
   resolution: "onetime@npm:5.1.2"
   dependencies:
@@ -5151,23 +4909,6 @@ __metadata:
   dependencies:
     mimic-fn: ^4.0.0
   checksum: 0846ce78e440841335d4e9182ef69d5762e9f38aa7499b19f42ea1c4cd40f0b4446094c455c713f9adac3f4ae86f613bb5e30c99e52652764d06a89f709b3788
-  languageName: node
-  linkType: hard
-
-"ora@npm:^5.4.1":
-  version: 5.4.1
-  resolution: "ora@npm:5.4.1"
-  dependencies:
-    bl: ^4.1.0
-    chalk: ^4.1.0
-    cli-cursor: ^3.1.0
-    cli-spinners: ^2.5.0
-    is-interactive: ^1.0.0
-    is-unicode-supported: ^0.1.0
-    log-symbols: ^4.1.0
-    strip-ansi: ^6.0.0
-    wcwidth: ^1.0.1
-  checksum: 28d476ee6c1049d68368c0dc922e7225e3b5600c3ede88fade8052837f9ed342625fdaa84a6209302587c8ddd9b664f71f0759833cbdb3a4cf81344057e63c63
   languageName: node
   linkType: hard
 
@@ -5204,7 +4945,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-key@npm:^3.0.0, path-key@npm:^3.1.0":
+"path-key@npm:^3.1.0":
   version: 3.1.1
   resolution: "path-key@npm:3.1.1"
   checksum: 55cd7a9dd4b343412a8386a743f9c746ef196e57c823d90ca3ab917f90ab9f13dd0ded27252ba49dbdfcab2b091d998bc446f6220cd3cea65db407502a740020
@@ -5489,16 +5230,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"restore-cursor@npm:^3.1.0":
-  version: 3.1.0
-  resolution: "restore-cursor@npm:3.1.0"
-  dependencies:
-    onetime: ^5.1.0
-    signal-exit: ^3.0.2
-  checksum: f877dd8741796b909f2a82454ec111afb84eb45890eb49ac947d87991379406b3b83ff9673a46012fca0d7844bb989f45cc5b788254cf1a39b6b5a9659de0630
-  languageName: node
-  linkType: hard
-
 "restore-cursor@npm:^4.0.0":
   version: 4.0.0
   resolution: "restore-cursor@npm:4.0.0"
@@ -5701,17 +5432,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"signal-exit@npm:^3.0.2, signal-exit@npm:^3.0.3, signal-exit@npm:^3.0.7":
+"signal-exit@npm:^3.0.2, signal-exit@npm:^3.0.7":
   version: 3.0.7
   resolution: "signal-exit@npm:3.0.7"
   checksum: a2f098f247adc367dffc27845853e9959b9e88b01cb301658cfe4194352d8d2bb32e18467c786a7fe15f1d44b233ea35633d076d5e737870b7139949d1ab6318
-  languageName: node
-  linkType: hard
-
-"slash@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "slash@npm:3.0.0"
-  checksum: 94a93fff615f25a999ad4b83c9d5e257a7280c90a32a7cb8b4a87996e4babf322e469c42b7f649fd5796edd8687652f3fb452a86dc97a816f01113183393f11c
   languageName: node
   linkType: hard
 
@@ -5875,7 +5599,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"strip-ansi@npm:^6.0.0, strip-ansi@npm:^6.0.1":
+"strip-ansi@npm:^6.0.1":
   version: 6.0.1
   resolution: "strip-ansi@npm:6.0.1"
   dependencies:
@@ -5904,13 +5628,6 @@ __metadata:
   version: 2.0.1
   resolution: "strip-comments@npm:2.0.1"
   checksum: 36cd122e1c27b5be69df87e1687770a62fe183bdee9f3ff5cf85d30bbc98280afc012581f2fd50c7ad077c90f656f272560c9d2e520d28604b8b7ea3bc87d6f9
-  languageName: node
-  linkType: hard
-
-"strip-final-newline@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "strip-final-newline@npm:2.0.0"
-  checksum: 69412b5e25731e1938184b5d489c32e340605bb611d6140344abc3421b7f3c6f9984b21dff296dfcf056681b82caa3bb4cc996a965ce37bcfad663e92eae9c64
   languageName: node
   linkType: hard
 
@@ -6235,18 +5952,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vue-router@npm:^4.1.2":
-  version: 4.1.3
-  resolution: "vue-router@npm:4.1.3"
-  dependencies:
-    "@vue/devtools-api": ^6.1.4
-  peerDependencies:
-    vue: ^3.2.0
-  checksum: 92a827a05e3afd5cc6ff6a4d033abaefae098b60e4d128b402bebb88473ad8ca485e675a6f7df2a5598ba4a8a23a2652c0f7c55c2c57c4ac433ce75fb4672222
-  languageName: node
-  linkType: hard
-
-"vue-router@npm:^4.1.6":
+"vue-router@npm:^4.1.3, vue-router@npm:^4.1.6":
   version: 4.1.6
   resolution: "vue-router@npm:4.1.6"
   dependencies:
@@ -6257,20 +5963,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vue@npm:^3.2.37":
-  version: 3.2.37
-  resolution: "vue@npm:3.2.37"
-  dependencies:
-    "@vue/compiler-dom": 3.2.37
-    "@vue/compiler-sfc": 3.2.37
-    "@vue/runtime-dom": 3.2.37
-    "@vue/server-renderer": 3.2.37
-    "@vue/shared": 3.2.37
-  checksum: cd20069c311e1de54b7d9b5d9c6021f1a6a70b0cf05cf7fc36b59c02623cbdc7c0075fb2c9e17859c77c86b15c596a447ee16c70064e9f2feba2df27139260b9
-  languageName: node
-  linkType: hard
-
-"vue@npm:^3.2.45":
+"vue@npm:^3.2.37, vue@npm:^3.2.45":
   version: 3.2.47
   resolution: "vue@npm:3.2.47"
   dependencies:
@@ -6391,7 +6084,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"workbox-build@npm:^6.5.3":
+"workbox-build@npm:^6.5.4":
   version: 6.5.4
   resolution: "workbox-build@npm:6.5.4"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1459,10 +1459,157 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/linux-loong64@npm:0.14.53":
-  version: 0.14.53
-  resolution: "@esbuild/linux-loong64@npm:0.14.53"
+"@esbuild/android-arm64@npm:0.16.17":
+  version: 0.16.17
+  resolution: "@esbuild/android-arm64@npm:0.16.17"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-arm@npm:0.16.17":
+  version: 0.16.17
+  resolution: "@esbuild/android-arm@npm:0.16.17"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-x64@npm:0.16.17":
+  version: 0.16.17
+  resolution: "@esbuild/android-x64@npm:0.16.17"
+  conditions: os=android & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/darwin-arm64@npm:0.16.17":
+  version: 0.16.17
+  resolution: "@esbuild/darwin-arm64@npm:0.16.17"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/darwin-x64@npm:0.16.17":
+  version: 0.16.17
+  resolution: "@esbuild/darwin-x64@npm:0.16.17"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/freebsd-arm64@npm:0.16.17":
+  version: 0.16.17
+  resolution: "@esbuild/freebsd-arm64@npm:0.16.17"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/freebsd-x64@npm:0.16.17":
+  version: 0.16.17
+  resolution: "@esbuild/freebsd-x64@npm:0.16.17"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-arm64@npm:0.16.17":
+  version: 0.16.17
+  resolution: "@esbuild/linux-arm64@npm:0.16.17"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-arm@npm:0.16.17":
+  version: 0.16.17
+  resolution: "@esbuild/linux-arm@npm:0.16.17"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-ia32@npm:0.16.17":
+  version: 0.16.17
+  resolution: "@esbuild/linux-ia32@npm:0.16.17"
+  conditions: os=linux & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-loong64@npm:0.16.17":
+  version: 0.16.17
+  resolution: "@esbuild/linux-loong64@npm:0.16.17"
   conditions: os=linux & cpu=loong64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-mips64el@npm:0.16.17":
+  version: 0.16.17
+  resolution: "@esbuild/linux-mips64el@npm:0.16.17"
+  conditions: os=linux & cpu=mips64el
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-ppc64@npm:0.16.17":
+  version: 0.16.17
+  resolution: "@esbuild/linux-ppc64@npm:0.16.17"
+  conditions: os=linux & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-riscv64@npm:0.16.17":
+  version: 0.16.17
+  resolution: "@esbuild/linux-riscv64@npm:0.16.17"
+  conditions: os=linux & cpu=riscv64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-s390x@npm:0.16.17":
+  version: 0.16.17
+  resolution: "@esbuild/linux-s390x@npm:0.16.17"
+  conditions: os=linux & cpu=s390x
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-x64@npm:0.16.17":
+  version: 0.16.17
+  resolution: "@esbuild/linux-x64@npm:0.16.17"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/netbsd-x64@npm:0.16.17":
+  version: 0.16.17
+  resolution: "@esbuild/netbsd-x64@npm:0.16.17"
+  conditions: os=netbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openbsd-x64@npm:0.16.17":
+  version: 0.16.17
+  resolution: "@esbuild/openbsd-x64@npm:0.16.17"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/sunos-x64@npm:0.16.17":
+  version: 0.16.17
+  resolution: "@esbuild/sunos-x64@npm:0.16.17"
+  conditions: os=sunos & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-arm64@npm:0.16.17":
+  version: 0.16.17
+  resolution: "@esbuild/win32-arm64@npm:0.16.17"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-ia32@npm:0.16.17":
+  version: 0.16.17
+  resolution: "@esbuild/win32-ia32@npm:0.16.17"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-x64@npm:0.16.17":
+  version: 0.16.17
+  resolution: "@esbuild/win32-x64@npm:0.16.17"
+  conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
@@ -1535,6 +1682,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@mdit-vue/plugin-component@npm:^0.11.2":
+  version: 0.11.2
+  resolution: "@mdit-vue/plugin-component@npm:0.11.2"
+  dependencies:
+    "@types/markdown-it": ^12.2.3
+    markdown-it: ^13.0.1
+  checksum: 6f7a2ec796cbeb02c9783b8ed4d1b3b3a08a96838588bef69cc054d791d60ac85145a5021ed044fcd3554570136270d40e60a3af6d7342e8841a27495f95eaca
+  languageName: node
+  linkType: hard
+
 "@mdit-vue/plugin-component@npm:^0.6.0":
   version: 0.6.0
   resolution: "@mdit-vue/plugin-component@npm:0.6.0"
@@ -1542,6 +1699,18 @@ __metadata:
     "@types/markdown-it": ^12.2.3
     markdown-it: ^13.0.1
   checksum: cef9e5b3b976531ad63f16f0f86363fd7afff01ff15b68734d1598569241f52b75aeafd1788266275efd96a0faab5b0aa53140cc695df6b655a3681d986e8b05
+  languageName: node
+  linkType: hard
+
+"@mdit-vue/plugin-frontmatter@npm:^0.11.1":
+  version: 0.11.1
+  resolution: "@mdit-vue/plugin-frontmatter@npm:0.11.1"
+  dependencies:
+    "@mdit-vue/types": 0.11.0
+    "@types/markdown-it": ^12.2.3
+    gray-matter: ^4.0.3
+    markdown-it: ^13.0.1
+  checksum: b19f446a710ba7ccff706eeb2385c5f09e0d954648807a0e57fda316abdc96d3d44ba7e55ba7b8e83273ef9faa96400355ba6e1c22088f86535c0544f5d9d87e
   languageName: node
   linkType: hard
 
@@ -1557,6 +1726,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@mdit-vue/plugin-headers@npm:^0.11.2":
+  version: 0.11.2
+  resolution: "@mdit-vue/plugin-headers@npm:0.11.2"
+  dependencies:
+    "@mdit-vue/shared": 0.11.2
+    "@mdit-vue/types": 0.11.0
+    "@types/markdown-it": ^12.2.3
+    markdown-it: ^13.0.1
+  checksum: 4c589ab19425b56f9c9283eeb3e8215936c1869692e1b559b8612f63a37d194562333b6c0cfe3cb8c970d7a70ffc02da6eeb9564684346738a5cecc2a707f786
+  languageName: node
+  linkType: hard
+
 "@mdit-vue/plugin-headers@npm:^0.6.0":
   version: 0.6.0
   resolution: "@mdit-vue/plugin-headers@npm:0.6.0"
@@ -1569,6 +1750,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@mdit-vue/plugin-sfc@npm:^0.11.1":
+  version: 0.11.1
+  resolution: "@mdit-vue/plugin-sfc@npm:0.11.1"
+  dependencies:
+    "@mdit-vue/types": 0.11.0
+    "@types/markdown-it": ^12.2.3
+    markdown-it: ^13.0.1
+  checksum: 50bc2e2765458b97dde6d4b71b2997ff09f7f89573173cd6622c96c53f670abfdb9e4b9ed65255653a1a4cba8016a0db94dd08ce7b0167040ed632799d315aff
+  languageName: node
+  linkType: hard
+
 "@mdit-vue/plugin-sfc@npm:^0.6.0":
   version: 0.6.0
   resolution: "@mdit-vue/plugin-sfc@npm:0.6.0"
@@ -1577,6 +1769,18 @@ __metadata:
     "@types/markdown-it": ^12.2.3
     markdown-it: ^13.0.1
   checksum: 942d57471c33be09797fee3865cf055a0c82716c025dffb7c68f724ee02aef4f93ebc7d8d377de1285516a7deb50866a07bb97b5760480e9593480e1bca9f0d9
+  languageName: node
+  linkType: hard
+
+"@mdit-vue/plugin-title@npm:^0.11.2":
+  version: 0.11.2
+  resolution: "@mdit-vue/plugin-title@npm:0.11.2"
+  dependencies:
+    "@mdit-vue/shared": 0.11.2
+    "@mdit-vue/types": 0.11.0
+    "@types/markdown-it": ^12.2.3
+    markdown-it: ^13.0.1
+  checksum: 5707b033ef1135c4c23622d8ab7f5e5241d739f99ed5c1e66d794a5dbbe4415de8b9ae020947feb7baa4ca5f035a3ee3945ec8030cc116368d11dde559292e1e
   languageName: node
   linkType: hard
 
@@ -1592,6 +1796,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@mdit-vue/plugin-toc@npm:^0.11.2":
+  version: 0.11.2
+  resolution: "@mdit-vue/plugin-toc@npm:0.11.2"
+  dependencies:
+    "@mdit-vue/shared": 0.11.2
+    "@mdit-vue/types": 0.11.0
+    "@types/markdown-it": ^12.2.3
+    markdown-it: ^13.0.1
+  checksum: 07379922ea270f57a5c272b690331a6e7459c9ebc3879f9edace361527d6ab965f7fd1d6d6e08b59ce96bca298648877c6b261d6e0a18deb76653ea38397509b
+  languageName: node
+  linkType: hard
+
 "@mdit-vue/plugin-toc@npm:^0.6.0":
   version: 0.6.0
   resolution: "@mdit-vue/plugin-toc@npm:0.6.0"
@@ -1604,6 +1820,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@mdit-vue/shared@npm:0.11.2, @mdit-vue/shared@npm:^0.11.2":
+  version: 0.11.2
+  resolution: "@mdit-vue/shared@npm:0.11.2"
+  dependencies:
+    "@mdit-vue/types": 0.11.0
+    "@types/markdown-it": ^12.2.3
+    markdown-it: ^13.0.1
+  checksum: 9284b0ba64d2a985c29ab7dd893f5982068ef02fa2081ebb4a81ec6a6e2674a377e4036414159df3ee00d45a45c8466c540a3841dc68efbca437ccd84ef01a75
+  languageName: node
+  linkType: hard
+
 "@mdit-vue/shared@npm:0.6.0, @mdit-vue/shared@npm:^0.6.0":
   version: 0.6.0
   resolution: "@mdit-vue/shared@npm:0.6.0"
@@ -1612,6 +1839,13 @@ __metadata:
     "@types/markdown-it": ^12.2.3
     markdown-it: ^13.0.1
   checksum: b96a92b21302b89b360219d17dcb5126c13e25fcdc53d76cada7e6814670256e05262857ded6b46119a5da574211ff10ef7edf389460e9841af8150b195f0b5f
+  languageName: node
+  linkType: hard
+
+"@mdit-vue/types@npm:0.11.0, @mdit-vue/types@npm:^0.11.0":
+  version: 0.11.0
+  resolution: "@mdit-vue/types@npm:0.11.0"
+  checksum: 3367608022b4d493e650175828458be377341aff0fce585166c4a5594b001ce6ffdccb687e780b18bf569823576460f1483669febf9820a065992501e011ca1f
   languageName: node
   linkType: hard
 
@@ -1771,6 +2005,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/hash-sum@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@types/hash-sum@npm:1.0.0"
+  checksum: 8eb446a86ed7a80c6a04f3083396bbbb7b34430ed553be161ff4e8e51d06d6f2755e6d2ffd059ad5ee8e059fbdadc6f838367781a893cc966811fde8f2c5aa47
+  languageName: node
+  linkType: hard
+
 "@types/linkify-it@npm:*":
   version: 3.0.2
   resolution: "@types/linkify-it@npm:3.0.2"
@@ -1834,20 +2075,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/web-bluetooth@npm:^0.0.14":
-  version: 0.0.14
-  resolution: "@types/web-bluetooth@npm:0.0.14"
-  checksum: 1eb694ff2ba6ef239e10024bfb205c087fb1a43aa8b4a31f3a3b7c90eccf2f55c7fb4c1057e382e1c2f4d6d8a137e68bf1255790b980c5ac95026419a623c6b5
+"@types/web-bluetooth@npm:^0.0.16":
+  version: 0.0.16
+  resolution: "@types/web-bluetooth@npm:0.0.16"
+  checksum: f68a630d062202a25c46d48686ebae1cf429dc70b4578fcf13b8357b2db63e4aedfb6f6d752bd388366be46ebd19c1c9de45f8a15c2631bb79e904fdfc454f94
   languageName: node
   linkType: hard
 
-"@vitejs/plugin-vue@npm:^2.3.3":
-  version: 2.3.3
-  resolution: "@vitejs/plugin-vue@npm:2.3.3"
+"@vitejs/plugin-vue@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "@vitejs/plugin-vue@npm:4.0.0"
   peerDependencies:
-    vite: ^2.5.10
+    vite: ^4.0.0
     vue: ^3.2.25
-  checksum: 9303dcb9c8580d0ee9b33542639ac1a36ad9cc0e773a1f9b9b05623d74574f6a901ce781918b53f5a58eb3c6218ba96c27ef6efbf3e7ef6be16864fc1cae1626
+  checksum: 5a53414912db644ca7a663d87c8d4838841dbf794772105c9b3bc3fb10214fc86c2f1f1a47350f264370e9a5fd2475f3b6882778b2440b5085d3fe7550ced542
   languageName: node
   linkType: hard
 
@@ -1863,6 +2104,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vue/compiler-core@npm:3.2.47":
+  version: 3.2.47
+  resolution: "@vue/compiler-core@npm:3.2.47"
+  dependencies:
+    "@babel/parser": ^7.16.4
+    "@vue/shared": 3.2.47
+    estree-walker: ^2.0.2
+    source-map: ^0.6.1
+  checksum: 9ccc2a0b897b59eea56ca4f92ed29c14cd1184f68532edf5fb0fe5cb2833bcf9e4836029effb6eb9a7c872e9e0350fafdcd96ff00c0b5b79e17ded0c068b5f84
+  languageName: node
+  linkType: hard
+
 "@vue/compiler-dom@npm:3.2.37":
   version: 3.2.37
   resolution: "@vue/compiler-dom@npm:3.2.37"
@@ -1870,6 +2123,16 @@ __metadata:
     "@vue/compiler-core": 3.2.37
     "@vue/shared": 3.2.37
   checksum: 6cfa9d2ee123339549ba005fa61b2cd5ccf079ba8d8d797f0075e7054c2766744029cb0997341bcb6a51e129ae43489263aa7d8500b262ef7b81c63c2b0c4576
+  languageName: node
+  linkType: hard
+
+"@vue/compiler-dom@npm:3.2.47":
+  version: 3.2.47
+  resolution: "@vue/compiler-dom@npm:3.2.47"
+  dependencies:
+    "@vue/compiler-core": 3.2.47
+    "@vue/shared": 3.2.47
+  checksum: 1eced735f865e6df0c2d7fa041f9f27996ff4c0d4baf5fad0f67e65e623215f4394c49bba337b78427c6e71f2cc2db12b19ec6b865b4c057c0a15ccedeb20752
   languageName: node
   linkType: hard
 
@@ -1891,6 +2154,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vue/compiler-sfc@npm:3.2.47":
+  version: 3.2.47
+  resolution: "@vue/compiler-sfc@npm:3.2.47"
+  dependencies:
+    "@babel/parser": ^7.16.4
+    "@vue/compiler-core": 3.2.47
+    "@vue/compiler-dom": 3.2.47
+    "@vue/compiler-ssr": 3.2.47
+    "@vue/reactivity-transform": 3.2.47
+    "@vue/shared": 3.2.47
+    estree-walker: ^2.0.2
+    magic-string: ^0.25.7
+    postcss: ^8.1.10
+    source-map: ^0.6.1
+  checksum: 4588a513310b9319a00adfdbe789cfe60d5ec19c51e8f2098152b9e81f54be170e16c40463f6b5e4c7ab79796fc31e2de93587a9dd1af136023fa03712b62e68
+  languageName: node
+  linkType: hard
+
 "@vue/compiler-ssr@npm:3.2.37":
   version: 3.2.37
   resolution: "@vue/compiler-ssr@npm:3.2.37"
@@ -1901,10 +2182,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vue/compiler-ssr@npm:3.2.47":
+  version: 3.2.47
+  resolution: "@vue/compiler-ssr@npm:3.2.47"
+  dependencies:
+    "@vue/compiler-dom": 3.2.47
+    "@vue/shared": 3.2.47
+  checksum: 91bc6e46744d5405713c08d8e576971aa6d13a0cde84ec592d3221bf6ee228e49ce12233af8c18dc39723455b420df2951f3616ceb99758eb432485475fa7bc2
+  languageName: node
+  linkType: hard
+
 "@vue/devtools-api@npm:^6.1.4, @vue/devtools-api@npm:^6.2.0":
   version: 6.2.1
   resolution: "@vue/devtools-api@npm:6.2.1"
   checksum: 34765af0be9b0cc7e3def73b2792b1514e3c348852c5a7503fe07d013f0e907af6c27c0a32c0637dd748caf37c075af8e53ca3220433e0bd34b6f3405f358272
+  languageName: node
+  linkType: hard
+
+"@vue/devtools-api@npm:^6.4.5":
+  version: 6.5.0
+  resolution: "@vue/devtools-api@npm:6.5.0"
+  checksum: ec819ef3a426e91d09e9cfefd2827e9ed8ec9d62bb3b3e0674f3da8c7e92a4b879c3b777dc7329172ca6fe2670b62dd5580d23160339208f0f5ae038f2e504ad
   languageName: node
   linkType: hard
 
@@ -1921,12 +2219,34 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vue/reactivity-transform@npm:3.2.47":
+  version: 3.2.47
+  resolution: "@vue/reactivity-transform@npm:3.2.47"
+  dependencies:
+    "@babel/parser": ^7.16.4
+    "@vue/compiler-core": 3.2.47
+    "@vue/shared": 3.2.47
+    estree-walker: ^2.0.2
+    magic-string: ^0.25.7
+  checksum: 6fe54374aa8c080c0c421e18134e84e723e2d3e53178cf084c1cd75bc8b1ffaaf07756801f3aa4e1e7ad1ba76356c28bbab4bc1b676159db8fc10f10f2cbd405
+  languageName: node
+  linkType: hard
+
 "@vue/reactivity@npm:3.2.37":
   version: 3.2.37
   resolution: "@vue/reactivity@npm:3.2.37"
   dependencies:
     "@vue/shared": 3.2.37
   checksum: 94e353f8b8a9301cae15c9366f2fec6a163efb7293e9fe5d1da3ed647f1859139b7b321451db56fb5e3141192c0f0755f74ca9c4bcd30ec44372e45def61d69f
+  languageName: node
+  linkType: hard
+
+"@vue/reactivity@npm:3.2.47":
+  version: 3.2.47
+  resolution: "@vue/reactivity@npm:3.2.47"
+  dependencies:
+    "@vue/shared": 3.2.47
+  checksum: bd61134e4b2f281067e78b23b34d17f1290a0b3fdb0cd7f06424570b4428c899389451a396694144b0af2fc6dbb1459c38e79151119f12c4f818f4c5004b7d16
   languageName: node
   linkType: hard
 
@@ -1940,6 +2260,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vue/runtime-core@npm:3.2.47":
+  version: 3.2.47
+  resolution: "@vue/runtime-core@npm:3.2.47"
+  dependencies:
+    "@vue/reactivity": 3.2.47
+    "@vue/shared": 3.2.47
+  checksum: 56fd41368cb56ac83d88ef93ffb9e8d2cdad30adf8395351c38ac744691dfe50c0add0bd14e8aa817cd59afd2534213eb2aaabf46b03aacce9a4af7497af2e69
+  languageName: node
+  linkType: hard
+
 "@vue/runtime-dom@npm:3.2.37":
   version: 3.2.37
   resolution: "@vue/runtime-dom@npm:3.2.37"
@@ -1948,6 +2278,17 @@ __metadata:
     "@vue/shared": 3.2.37
     csstype: ^2.6.8
   checksum: 36dddfd56161c94a9a483903a570897e1ee46a95126d54f7948bc184d5d333c9f0c1a9c4cee90ddec63baf4ea2e35be9d0d678108427aba907b0adf0800c75a5
+  languageName: node
+  linkType: hard
+
+"@vue/runtime-dom@npm:3.2.47":
+  version: 3.2.47
+  resolution: "@vue/runtime-dom@npm:3.2.47"
+  dependencies:
+    "@vue/runtime-core": 3.2.47
+    "@vue/shared": 3.2.47
+    csstype: ^2.6.8
+  checksum: 8987d7276174120ed346c456752cdb3633c400432ae89a1a866e342c964b7ed2f9e3e09926f2b4b81fe175b1e4fb3935fe3920c113bcc71464ff39b4e50931f5
   languageName: node
   linkType: hard
 
@@ -1963,6 +2304,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vue/server-renderer@npm:3.2.47":
+  version: 3.2.47
+  resolution: "@vue/server-renderer@npm:3.2.47"
+  dependencies:
+    "@vue/compiler-ssr": 3.2.47
+    "@vue/shared": 3.2.47
+  peerDependencies:
+    vue: 3.2.47
+  checksum: 482fe3c9bbb0e154864259a976bac50f5a6cbbb86bc4376c5942a6108919466e57d9830c65060abff6ecb6a9ff1d5e3e4fede165f4312edf25b0088b8c0e26af
+  languageName: node
+  linkType: hard
+
 "@vue/shared@npm:3.2.37, @vue/shared@npm:^3.2.37":
   version: 3.2.37
   resolution: "@vue/shared@npm:3.2.37"
@@ -1970,40 +2323,48 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vuepress/bundler-vite@npm:2.0.0-beta.49":
-  version: 2.0.0-beta.49
-  resolution: "@vuepress/bundler-vite@npm:2.0.0-beta.49"
-  dependencies:
-    "@vitejs/plugin-vue": ^2.3.3
-    "@vuepress/client": 2.0.0-beta.49
-    "@vuepress/core": 2.0.0-beta.49
-    "@vuepress/shared": 2.0.0-beta.49
-    "@vuepress/utils": 2.0.0-beta.49
-    autoprefixer: ^10.4.7
-    connect-history-api-fallback: ^2.0.0
-    postcss: ^8.4.14
-    rollup: ^2.76.0
-    vite: ~2.9.14
-    vue: ^3.2.37
-    vue-router: ^4.1.2
-  checksum: 162ac47ba472fabf1ecc767d8bbf11926a5f6f486dbaab108bc4c3cad34e4bb295a347af59195f35787d2e9f57603ccdfd518e4110a5d6d52e3f1f43013b536c
+"@vue/shared@npm:3.2.47, @vue/shared@npm:^3.2.45":
+  version: 3.2.47
+  resolution: "@vue/shared@npm:3.2.47"
+  checksum: 0aa711dc9160fa0e476e6e94eea4e019398adf2211352d0e4a672cfb6b65b104bbd5d234807d1c091107bdc0f5d818d0f12378987eb7861d39be3aa9f6cd6e3e
   languageName: node
   linkType: hard
 
-"@vuepress/cli@npm:2.0.0-beta.49":
-  version: 2.0.0-beta.49
-  resolution: "@vuepress/cli@npm:2.0.0-beta.49"
+"@vuepress/bundler-vite@npm:2.0.0-beta.60":
+  version: 2.0.0-beta.60
+  resolution: "@vuepress/bundler-vite@npm:2.0.0-beta.60"
   dependencies:
-    "@vuepress/core": 2.0.0-beta.49
-    "@vuepress/shared": 2.0.0-beta.49
-    "@vuepress/utils": 2.0.0-beta.49
-    cac: ^6.7.12
+    "@vitejs/plugin-vue": ^4.0.0
+    "@vuepress/client": 2.0.0-beta.60
+    "@vuepress/core": 2.0.0-beta.60
+    "@vuepress/shared": 2.0.0-beta.60
+    "@vuepress/utils": 2.0.0-beta.60
+    autoprefixer: ^10.4.13
+    connect-history-api-fallback: ^2.0.0
+    postcss: ^8.4.20
+    postcss-load-config: ^4.0.1
+    rollup: ^3.9.0
+    vite: ~4.0.3
+    vue: ^3.2.45
+    vue-router: ^4.1.6
+  checksum: 3c6b1076080f5553cc46d486f2704f9838a71acead1d8ed42b66de72d2924ce3d02f33b5af979ae4a89ebcbf3ae05be68a20fd04667dd7e82f28118c86763e65
+  languageName: node
+  linkType: hard
+
+"@vuepress/cli@npm:2.0.0-beta.60":
+  version: 2.0.0-beta.60
+  resolution: "@vuepress/cli@npm:2.0.0-beta.60"
+  dependencies:
+    "@vuepress/core": 2.0.0-beta.60
+    "@vuepress/shared": 2.0.0-beta.60
+    "@vuepress/utils": 2.0.0-beta.60
+    cac: ^6.7.14
     chokidar: ^3.5.3
     envinfo: ^7.8.1
-    esbuild: ^0.14.49
+    esbuild: ^0.16.12
   bin:
     vuepress-cli: bin/vuepress.js
-  checksum: 4aca4f94aa843071a9afe66d7d7dba826d0ba0e3732ec02c917aa063f8f7d1b9753513ea865cb286abc45b8cdc93f9eb939e8c9cd63aa2fa98363fd8ba6a4f4b
+  checksum: 6fa6e7604ff2fd19e7047ff617357407c8d221cbc2baec235694556daf4fc7006ee52bd1044978badd5e35bf83a87e3d2471c69bf406cfb0aa166f23d48210b0
   languageName: node
   linkType: hard
 
@@ -2019,6 +2380,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vuepress/client@npm:2.0.0-beta.60":
+  version: 2.0.0-beta.60
+  resolution: "@vuepress/client@npm:2.0.0-beta.60"
+  dependencies:
+    "@vue/devtools-api": ^6.4.5
+    "@vuepress/shared": 2.0.0-beta.60
+    vue: ^3.2.45
+    vue-router: ^4.1.6
+  checksum: 39f6857e8c82750579a57317194973b5fe2024e3beda73a25537a4076a134cabc0b17b5816c9d8fb723c93e0b7c927d2e30d3780815a9cc3fe3bb82d05e0eaf2
+  languageName: node
+  linkType: hard
+
 "@vuepress/core@npm:2.0.0-beta.49":
   version: 2.0.0-beta.49
   resolution: "@vuepress/core@npm:2.0.0-beta.49"
@@ -2029,6 +2402,19 @@ __metadata:
     "@vuepress/utils": 2.0.0-beta.49
     vue: ^3.2.37
   checksum: 504ad06d932ba8258fa230c4247ae55d2ca423353da910ab38a04f8dc242acb683096d57f3777445aa9b1a70ca8a4c7499e56a54a27a0637918a91c2b09389aa
+  languageName: node
+  linkType: hard
+
+"@vuepress/core@npm:2.0.0-beta.60":
+  version: 2.0.0-beta.60
+  resolution: "@vuepress/core@npm:2.0.0-beta.60"
+  dependencies:
+    "@vuepress/client": 2.0.0-beta.60
+    "@vuepress/markdown": 2.0.0-beta.60
+    "@vuepress/shared": 2.0.0-beta.60
+    "@vuepress/utils": 2.0.0-beta.60
+    vue: ^3.2.45
+  checksum: 8c9b84c9e250ee88478eb251f083cb4b7de06bdd9eb9c9a6ffbd16b30de909acdef874ffcaacb48d8d9faaa5895ab636564170696104378ad93e21ffbd59836a
   languageName: node
   linkType: hard
 
@@ -2056,45 +2442,69 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vuepress/plugin-active-header-links@npm:2.0.0-beta.49":
-  version: 2.0.0-beta.49
-  resolution: "@vuepress/plugin-active-header-links@npm:2.0.0-beta.49"
+"@vuepress/markdown@npm:2.0.0-beta.60":
+  version: 2.0.0-beta.60
+  resolution: "@vuepress/markdown@npm:2.0.0-beta.60"
   dependencies:
-    "@vuepress/client": 2.0.0-beta.49
-    "@vuepress/core": 2.0.0-beta.49
-    "@vuepress/utils": 2.0.0-beta.49
-    ts-debounce: ^4.0.0
-    vue: ^3.2.37
-    vue-router: ^4.1.2
-  checksum: 9be48e31bbb5aac40db85bf0d27a53c53756bfe1eb6291e773affd6c2ac8bdd6315f69ad53c70a43d579704c9371f0ecdbf51d7fb5e851432bdf518781424b41
+    "@mdit-vue/plugin-component": ^0.11.2
+    "@mdit-vue/plugin-frontmatter": ^0.11.1
+    "@mdit-vue/plugin-headers": ^0.11.2
+    "@mdit-vue/plugin-sfc": ^0.11.1
+    "@mdit-vue/plugin-title": ^0.11.2
+    "@mdit-vue/plugin-toc": ^0.11.2
+    "@mdit-vue/shared": ^0.11.2
+    "@mdit-vue/types": ^0.11.0
+    "@types/markdown-it": ^12.2.3
+    "@types/markdown-it-emoji": ^2.0.2
+    "@vuepress/shared": 2.0.0-beta.60
+    "@vuepress/utils": 2.0.0-beta.60
+    markdown-it: ^13.0.1
+    markdown-it-anchor: ^8.6.6
+    markdown-it-emoji: ^2.0.2
+    mdurl: ^1.0.1
+  checksum: f811e2c27732f5fa7f4b7a26c4dc98e437692a4f933e53a22b437d7926a542e5738dffc08c954c8963b600837723c2bb6e953d01dd7c86091c68a9338e564569
   languageName: node
   linkType: hard
 
-"@vuepress/plugin-back-to-top@npm:2.0.0-beta.49":
-  version: 2.0.0-beta.49
-  resolution: "@vuepress/plugin-back-to-top@npm:2.0.0-beta.49"
+"@vuepress/plugin-active-header-links@npm:2.0.0-beta.60":
+  version: 2.0.0-beta.60
+  resolution: "@vuepress/plugin-active-header-links@npm:2.0.0-beta.60"
   dependencies:
-    "@vuepress/client": 2.0.0-beta.49
-    "@vuepress/core": 2.0.0-beta.49
-    "@vuepress/utils": 2.0.0-beta.49
+    "@vuepress/client": 2.0.0-beta.60
+    "@vuepress/core": 2.0.0-beta.60
+    "@vuepress/utils": 2.0.0-beta.60
     ts-debounce: ^4.0.0
-    vue: ^3.2.37
-  checksum: bc3d12ba016bf7af62c0faff67b63aaee3a766db0463871ec80bb8891a25639b2491c2011b50afd43986f1b54bcdfaaf972481b79257531ac5746e5138d7711b
+    vue: ^3.2.45
+    vue-router: ^4.1.6
+  checksum: 41b201d11a6ccbfabfc3ec217875c1912e2da18c0a2890cc3f47d870fe77682545f04f94f598ab52cff21598ef59ae92a86189b93c1e1971f2511ab05343ee1c
   languageName: node
   linkType: hard
 
-"@vuepress/plugin-container@npm:2.0.0-beta.49":
-  version: 2.0.0-beta.49
-  resolution: "@vuepress/plugin-container@npm:2.0.0-beta.49"
+"@vuepress/plugin-back-to-top@npm:2.0.0-beta.60":
+  version: 2.0.0-beta.60
+  resolution: "@vuepress/plugin-back-to-top@npm:2.0.0-beta.60"
+  dependencies:
+    "@vuepress/client": 2.0.0-beta.60
+    "@vuepress/core": 2.0.0-beta.60
+    "@vuepress/utils": 2.0.0-beta.60
+    ts-debounce: ^4.0.0
+    vue: ^3.2.45
+  checksum: 3b46f731f1550bcd5d2fe5933d0d02d1cc7cd23b23dcdeb5239fba2ae0cf88441ab608df4830facdc842be9c582ef67b10513881845a92a1b1365ed8de672536
+  languageName: node
+  linkType: hard
+
+"@vuepress/plugin-container@npm:2.0.0-beta.60":
+  version: 2.0.0-beta.60
+  resolution: "@vuepress/plugin-container@npm:2.0.0-beta.60"
   dependencies:
     "@types/markdown-it": ^12.2.3
-    "@vuepress/core": 2.0.0-beta.49
-    "@vuepress/markdown": 2.0.0-beta.49
-    "@vuepress/shared": 2.0.0-beta.49
-    "@vuepress/utils": 2.0.0-beta.49
+    "@vuepress/core": 2.0.0-beta.60
+    "@vuepress/markdown": 2.0.0-beta.60
+    "@vuepress/shared": 2.0.0-beta.60
+    "@vuepress/utils": 2.0.0-beta.60
     markdown-it: ^13.0.1
     markdown-it-container: ^3.0.0
-  checksum: 96afe967dde1f4d9ec0686dc8c8cb6a3610d86ebf8c8e64a7bf474cd132173b0a3b1dedbfe44cc1e4b739eadb5c5b86d85eff59c8b888b64f9efca69b39c2bf2
+  checksum: 571bd3a832d8a81e1feca420b780ed138466cc1b44fd2c2bdf5a7e2e6a14912215129ab0ce4ccc2bb4e00a180b7681772b63757165855d3036f8588bc06be33d
   languageName: node
   linkType: hard
 
@@ -2116,21 +2526,32 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vuepress/plugin-external-link-icon@npm:2.0.0-beta.49":
-  version: 2.0.0-beta.49
-  resolution: "@vuepress/plugin-external-link-icon@npm:2.0.0-beta.49"
+"@vuepress/plugin-external-link-icon@npm:2.0.0-beta.60":
+  version: 2.0.0-beta.60
+  resolution: "@vuepress/plugin-external-link-icon@npm:2.0.0-beta.60"
   dependencies:
-    "@vuepress/client": 2.0.0-beta.49
-    "@vuepress/core": 2.0.0-beta.49
-    "@vuepress/markdown": 2.0.0-beta.49
-    "@vuepress/shared": 2.0.0-beta.49
-    "@vuepress/utils": 2.0.0-beta.49
-    vue: ^3.2.37
-  checksum: 81d343de6a2fefc10b10fd416d41b69bfbf99b74c8ac29edc85ffb971985f5a2b69b389c9f76c0b05b3bc4f659304f22930058bff7471473c2a5c7ce405f13ee
+    "@vuepress/client": 2.0.0-beta.60
+    "@vuepress/core": 2.0.0-beta.60
+    "@vuepress/markdown": 2.0.0-beta.60
+    "@vuepress/shared": 2.0.0-beta.60
+    "@vuepress/utils": 2.0.0-beta.60
+    vue: ^3.2.45
+  checksum: 9b0084a37e53c17dce5f5575dd1b271b9b80f5af37804a4641bdfae098c56f480df17a0f85463df2b7f36eb2654514dae497457dae5596ab43c26e1a254cdd8f
   languageName: node
   linkType: hard
 
-"@vuepress/plugin-git@npm:2.0.0-beta.49, @vuepress/plugin-git@npm:^2.0.0-beta.48":
+"@vuepress/plugin-git@npm:2.0.0-beta.60":
+  version: 2.0.0-beta.60
+  resolution: "@vuepress/plugin-git@npm:2.0.0-beta.60"
+  dependencies:
+    "@vuepress/core": 2.0.0-beta.60
+    "@vuepress/utils": 2.0.0-beta.60
+    execa: ^6.1.0
+  checksum: 52a423e92a097fcc1aee34715e13e5ddcc2805e2d2d1ae29164b2d92fbac061b485ec81387f44e66bda5b14470927d7bfd9ad02f6c7579a71a7d0ce0adf0befd
+  languageName: node
+  linkType: hard
+
+"@vuepress/plugin-git@npm:^2.0.0-beta.48":
   version: 2.0.0-beta.49
   resolution: "@vuepress/plugin-git@npm:2.0.0-beta.49"
   dependencies:
@@ -2152,50 +2573,50 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vuepress/plugin-medium-zoom@npm:2.0.0-beta.49":
-  version: 2.0.0-beta.49
-  resolution: "@vuepress/plugin-medium-zoom@npm:2.0.0-beta.49"
+"@vuepress/plugin-medium-zoom@npm:2.0.0-beta.60":
+  version: 2.0.0-beta.60
+  resolution: "@vuepress/plugin-medium-zoom@npm:2.0.0-beta.60"
   dependencies:
-    "@vuepress/client": 2.0.0-beta.49
-    "@vuepress/core": 2.0.0-beta.49
-    "@vuepress/utils": 2.0.0-beta.49
-    medium-zoom: ^1.0.6
-    vue: ^3.2.37
-  checksum: e936a8205d2d01ed77a69927ce6e681a33690e072891b4ea2885c967e1da7e779f3611ea9239c73dfb8faed91334941da52f9f5ca52164b944411e54586a8e7b
+    "@vuepress/client": 2.0.0-beta.60
+    "@vuepress/core": 2.0.0-beta.60
+    "@vuepress/utils": 2.0.0-beta.60
+    medium-zoom: ^1.0.8
+    vue: ^3.2.45
+  checksum: fa20281dd2e89759f7e159116b37d2efb9505afb83ae1895927631ae312a17c89093ef5315c1648d41568370c2180de673d9bf9cfcdd66bb7aeab8a77a61c031
   languageName: node
   linkType: hard
 
-"@vuepress/plugin-nprogress@npm:2.0.0-beta.49":
-  version: 2.0.0-beta.49
-  resolution: "@vuepress/plugin-nprogress@npm:2.0.0-beta.49"
+"@vuepress/plugin-nprogress@npm:2.0.0-beta.60":
+  version: 2.0.0-beta.60
+  resolution: "@vuepress/plugin-nprogress@npm:2.0.0-beta.60"
   dependencies:
-    "@vuepress/client": 2.0.0-beta.49
-    "@vuepress/core": 2.0.0-beta.49
-    "@vuepress/utils": 2.0.0-beta.49
-    vue: ^3.2.37
-    vue-router: ^4.1.2
-  checksum: 20f396365226ca80ea578b34403f79c40f1628240f07a3201e2e0bb8b64fdc8afe1bccd76158ed02e67eb23e2ffd899e5662b1bc22b5f84c489110c07902883c
+    "@vuepress/client": 2.0.0-beta.60
+    "@vuepress/core": 2.0.0-beta.60
+    "@vuepress/utils": 2.0.0-beta.60
+    vue: ^3.2.45
+    vue-router: ^4.1.6
+  checksum: ab4e6587a85fea4bcb14cd25a12340e01367536d95e6c4c20c27d5b3d597762752b7543d4773a769399422dc02c337b29d27550f99785c2b82c8a83c183dafc9
   languageName: node
   linkType: hard
 
-"@vuepress/plugin-palette@npm:2.0.0-beta.49":
-  version: 2.0.0-beta.49
-  resolution: "@vuepress/plugin-palette@npm:2.0.0-beta.49"
+"@vuepress/plugin-palette@npm:2.0.0-beta.60":
+  version: 2.0.0-beta.60
+  resolution: "@vuepress/plugin-palette@npm:2.0.0-beta.60"
   dependencies:
-    "@vuepress/core": 2.0.0-beta.49
-    "@vuepress/utils": 2.0.0-beta.49
+    "@vuepress/core": 2.0.0-beta.60
+    "@vuepress/utils": 2.0.0-beta.60
     chokidar: ^3.5.3
-  checksum: e334164cab696947cc726842b34557937322ea2ba23ff9a934437cefc3fe616e12c4907d86830ec5878cc2a6191be0fc999abddf474f01d4ed3056b93bbccfc4
+  checksum: 8f287c540a21a40751e7b9cc8f2a8b247109486261e4f3b0244809133d904259d15d510f45333d80e2d6b30f8dde737719a37d063084b91240ba6f508f6fbee6
   languageName: node
   linkType: hard
 
-"@vuepress/plugin-prismjs@npm:2.0.0-beta.49":
-  version: 2.0.0-beta.49
-  resolution: "@vuepress/plugin-prismjs@npm:2.0.0-beta.49"
+"@vuepress/plugin-prismjs@npm:2.0.0-beta.60":
+  version: 2.0.0-beta.60
+  resolution: "@vuepress/plugin-prismjs@npm:2.0.0-beta.60"
   dependencies:
-    "@vuepress/core": 2.0.0-beta.49
-    prismjs: ^1.28.0
-  checksum: 498c7e6e243c680186a120be6ec44aa70e02ce9daba497fd18909982566a1b3ec42ddd1eb52df17ae0b38cf1527a7ee5854d4175371287311af7559be0a9db8f
+    "@vuepress/core": 2.0.0-beta.60
+    prismjs: ^1.29.0
+  checksum: 733de6c035725e5fcff1b1ddb5e3e238b4a57b32116042dce42bfe1d25dc6bbec299eac08f54b91bd5986f5f3e4345c70e4b9f2527bbfb4f218dc1cc94035cc2
   languageName: node
   linkType: hard
 
@@ -2214,17 +2635,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vuepress/plugin-theme-data@npm:2.0.0-beta.49":
-  version: 2.0.0-beta.49
-  resolution: "@vuepress/plugin-theme-data@npm:2.0.0-beta.49"
+"@vuepress/plugin-theme-data@npm:2.0.0-beta.60":
+  version: 2.0.0-beta.60
+  resolution: "@vuepress/plugin-theme-data@npm:2.0.0-beta.60"
   dependencies:
-    "@vue/devtools-api": ^6.2.0
-    "@vuepress/client": 2.0.0-beta.49
-    "@vuepress/core": 2.0.0-beta.49
-    "@vuepress/shared": 2.0.0-beta.49
-    "@vuepress/utils": 2.0.0-beta.49
-    vue: ^3.2.37
-  checksum: eb6c131f402ed9a9242f559193905ec876e3eb9e0427199ad75b4d05f44fe80c4005dddf954d5ffd56dcd1f65e4cdeb444d24483a19cdcd840724843d2cd898d
+    "@vue/devtools-api": ^6.4.5
+    "@vuepress/client": 2.0.0-beta.60
+    "@vuepress/core": 2.0.0-beta.60
+    "@vuepress/shared": 2.0.0-beta.60
+    "@vuepress/utils": 2.0.0-beta.60
+    vue: ^3.2.45
+  checksum: f52d88bcda717d7f82f17115cf1dc46b4f583eefcf9b3b38c0a2749c7a6911120108ffc81fcf5d99522169d3f854492acaf50a214ff912fb4086d904e00dcf8c
   languageName: node
   linkType: hard
 
@@ -2237,34 +2658,44 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vuepress/theme-default@npm:2.0.0-beta.49":
-  version: 2.0.0-beta.49
-  resolution: "@vuepress/theme-default@npm:2.0.0-beta.49"
+"@vuepress/shared@npm:2.0.0-beta.60":
+  version: 2.0.0-beta.60
+  resolution: "@vuepress/shared@npm:2.0.0-beta.60"
   dependencies:
-    "@vuepress/client": 2.0.0-beta.49
-    "@vuepress/core": 2.0.0-beta.49
-    "@vuepress/plugin-active-header-links": 2.0.0-beta.49
-    "@vuepress/plugin-back-to-top": 2.0.0-beta.49
-    "@vuepress/plugin-container": 2.0.0-beta.49
-    "@vuepress/plugin-external-link-icon": 2.0.0-beta.49
-    "@vuepress/plugin-git": 2.0.0-beta.49
-    "@vuepress/plugin-medium-zoom": 2.0.0-beta.49
-    "@vuepress/plugin-nprogress": 2.0.0-beta.49
-    "@vuepress/plugin-palette": 2.0.0-beta.49
-    "@vuepress/plugin-prismjs": 2.0.0-beta.49
-    "@vuepress/plugin-theme-data": 2.0.0-beta.49
-    "@vuepress/shared": 2.0.0-beta.49
-    "@vuepress/utils": 2.0.0-beta.49
-    "@vueuse/core": ^8.7.5
-    sass: ^1.53.0
-    vue: ^3.2.37
-    vue-router: ^4.1.2
+    "@mdit-vue/types": ^0.11.0
+    "@vue/shared": ^3.2.45
+  checksum: dfe6c360888db4be2c447b495ab148a55576b70ab3b94356449f34663850fa1272c11ed602f6509d5fb54b39e1a6423566d4be8868f1e309457f4ceab72b9081
+  languageName: node
+  linkType: hard
+
+"@vuepress/theme-default@npm:2.0.0-beta.60":
+  version: 2.0.0-beta.60
+  resolution: "@vuepress/theme-default@npm:2.0.0-beta.60"
+  dependencies:
+    "@vuepress/client": 2.0.0-beta.60
+    "@vuepress/core": 2.0.0-beta.60
+    "@vuepress/plugin-active-header-links": 2.0.0-beta.60
+    "@vuepress/plugin-back-to-top": 2.0.0-beta.60
+    "@vuepress/plugin-container": 2.0.0-beta.60
+    "@vuepress/plugin-external-link-icon": 2.0.0-beta.60
+    "@vuepress/plugin-git": 2.0.0-beta.60
+    "@vuepress/plugin-medium-zoom": 2.0.0-beta.60
+    "@vuepress/plugin-nprogress": 2.0.0-beta.60
+    "@vuepress/plugin-palette": 2.0.0-beta.60
+    "@vuepress/plugin-prismjs": 2.0.0-beta.60
+    "@vuepress/plugin-theme-data": 2.0.0-beta.60
+    "@vuepress/shared": 2.0.0-beta.60
+    "@vuepress/utils": 2.0.0-beta.60
+    "@vueuse/core": ^9.9.0
+    sass: ^1.57.1
+    vue: ^3.2.45
+    vue-router: ^4.1.6
   peerDependencies:
-    sass-loader: ^13.0.0
+    sass-loader: ^13.2.0
   peerDependenciesMeta:
     sass-loader:
       optional: true
-  checksum: 3e0332ea8663247ad316ececce5848bb8b3851ea8151567f2a46c6ac7e52461e5b31c18819793a93b47f02f8dfdada5db98391e6eaf4c103760611dec7baba62
+  checksum: d697dd9804e0eeca7f1a66572a0652f9c05a43475867b7ba5ede61480da63d341295d4acacc7be349e71fcd232468e93e5bbe26bd052d98df26c55b91ee4409a
   languageName: node
   linkType: hard
 
@@ -2286,47 +2717,50 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vueuse/core@npm:^8.7.5":
-  version: 8.9.4
-  resolution: "@vueuse/core@npm:8.9.4"
+"@vuepress/utils@npm:2.0.0-beta.60":
+  version: 2.0.0-beta.60
+  resolution: "@vuepress/utils@npm:2.0.0-beta.60"
   dependencies:
-    "@types/web-bluetooth": ^0.0.14
-    "@vueuse/metadata": 8.9.4
-    "@vueuse/shared": 8.9.4
-    vue-demi: "*"
-  peerDependencies:
-    "@vue/composition-api": ^1.1.0
-    vue: ^2.6.0 || ^3.2.0
-  peerDependenciesMeta:
-    "@vue/composition-api":
-      optional: true
-    vue:
-      optional: true
-  checksum: 4f19874884d246e724562051143f27e18d7e7aefb941d4417e785027b87a895aea7ed51f3c9d6c1af219ea33d41cc1e0fcba113b72922ce6057a518cb0b83572
+    "@types/debug": ^4.1.7
+    "@types/fs-extra": ^9.0.13
+    "@types/hash-sum": ^1.0.0
+    "@vuepress/shared": 2.0.0-beta.60
+    debug: ^4.3.4
+    fs-extra: ^11.1.0
+    globby: ^13.1.3
+    hash-sum: ^2.0.0
+    ora: ^6.1.2
+    picocolors: ^1.0.0
+    upath: ^2.0.1
+  checksum: fd1fd6e55ff8f02639e7c376c4003868f5655e321f694a17f25f3d8f010f0cc8abfd5c7cc84c6a53f6e0726f6c00061ddd497b6ac3836c53abdd272e21101e7c
   languageName: node
   linkType: hard
 
-"@vueuse/metadata@npm:8.9.4":
-  version: 8.9.4
-  resolution: "@vueuse/metadata@npm:8.9.4"
-  checksum: f289adc73d7d396e0245b0f219126811556497dcc093008b2b9e8c9023196c52eb5918dce4f5f6cc3a01db9c6a699b6adfc678800a1b543f6cc1c857d5643526
+"@vueuse/core@npm:^9.9.0":
+  version: 9.12.0
+  resolution: "@vueuse/core@npm:9.12.0"
+  dependencies:
+    "@types/web-bluetooth": ^0.0.16
+    "@vueuse/metadata": 9.12.0
+    "@vueuse/shared": 9.12.0
+    vue-demi: "*"
+  checksum: bbbbd0a60f3cbda8e116c721f67319af42247af607d997e58d1f860660148ecbf58f90b8b3f38c6ecf87bc37a1a330b280050d883d79579ed72abf3b286b88cb
   languageName: node
   linkType: hard
 
-"@vueuse/shared@npm:8.9.4":
-  version: 8.9.4
-  resolution: "@vueuse/shared@npm:8.9.4"
+"@vueuse/metadata@npm:9.12.0":
+  version: 9.12.0
+  resolution: "@vueuse/metadata@npm:9.12.0"
+  checksum: ce732fbf313e3a3ed4ebddcace4cca05907c297103a20bc7e3e25cfb58dbce4b8e6b5d6a68a41922a821e07fa627321534068f9d494190d0bc5b95f1c29e8dcf
+  languageName: node
+  linkType: hard
+
+"@vueuse/shared@npm:9.12.0":
+  version: 9.12.0
+  resolution: "@vueuse/shared@npm:9.12.0"
   dependencies:
     vue-demi: "*"
-  peerDependencies:
-    "@vue/composition-api": ^1.1.0
-    vue: ^2.6.0 || ^3.2.0
-  peerDependenciesMeta:
-    "@vue/composition-api":
-      optional: true
-    vue:
-      optional: true
-  checksum: 83a29ec879073100e268863f607b3a8175ac1d70318b85f74907ed69bcf0d538f89b2ccd3c14ac37eab326ec3564e0c1623f1f9af0980516a5617e7f81fdd9bb
+  checksum: b359e78dddef960c7456c0bad7427ad255239740ae02485ac64ed5df3f58387253647cf243a0839f9eb014e91f315db850745ab5930e22a0c52434d1619bc04e
   languageName: node
   linkType: hard
 
@@ -2417,6 +2851,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ansi-regex@npm:^6.0.1":
+  version: 6.0.1
+  resolution: "ansi-regex@npm:6.0.1"
+  checksum: 1ff8b7667cded1de4fa2c9ae283e979fc87036864317da86a2e546725f96406746411d0d85e87a2d12fa5abd715d90006de7fa4fa0477c92321ad3b4c7d4e169
+  languageName: node
+  linkType: hard
+
 "ansi-styles@npm:^3.2.1":
   version: 3.2.1
   resolution: "ansi-styles@npm:3.2.1"
@@ -2499,12 +2940,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"autoprefixer@npm:^10.4.7":
-  version: 10.4.8
-  resolution: "autoprefixer@npm:10.4.8"
+"autoprefixer@npm:^10.4.13":
+  version: 10.4.13
+  resolution: "autoprefixer@npm:10.4.13"
   dependencies:
-    browserslist: ^4.21.3
-    caniuse-lite: ^1.0.30001373
+    browserslist: ^4.21.4
+    caniuse-lite: ^1.0.30001426
     fraction.js: ^4.2.0
     normalize-range: ^0.1.2
     picocolors: ^1.0.0
@@ -2513,7 +2954,7 @@ __metadata:
     postcss: ^8.1.0
   bin:
     autoprefixer: bin/autoprefixer
-  checksum: 06cb4c497bb948714d5b1b4f7e7465fd88c50f90788fc2020b3d97d7661fb4dd0d9918c1b09dd3e909acd4485cbb27ad99085487d8ed5d75915e646d2b535770
+  checksum: dcb1cb7ae96a3363d65d82e52f9a0a7d8c982256f6fd032d7e1ec311f099c23acfebfd517ff8e96bf93f716a66c4ea2b80c60aa19efd2f474ce434bd75ef7b79
   languageName: node
   linkType: hard
 
@@ -2526,7 +2967,7 @@ __metadata:
     "@vuepress/plugin-google-analytics": ^2.0.0-beta.48
     "@vuepress/plugin-pwa": ^2.0.0-beta.48
     markdownlint-cli2: ^0.6.0
-    vuepress: ^2.0.0-beta.48
+    vuepress: ^2.0.0-beta.60
   languageName: unknown
   linkType: soft
 
@@ -2607,6 +3048,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"bl@npm:^5.0.0":
+  version: 5.1.0
+  resolution: "bl@npm:5.1.0"
+  dependencies:
+    buffer: ^6.0.3
+    inherits: ^2.0.4
+    readable-stream: ^3.4.0
+  checksum: a7a438ee0bc540e80b8eb68cc1ad759a9c87df06874a99411d701d01cc0b36f30cd20050512ac3e77090138890960e07bfee724f3ee6619bb39a569f5cc3b1bc
+  languageName: node
+  linkType: hard
+
 "brace-expansion@npm:^1.1.7":
   version: 1.1.11
   resolution: "brace-expansion@npm:1.1.11"
@@ -2649,6 +3101,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"browserslist@npm:^4.21.4":
+  version: 4.21.5
+  resolution: "browserslist@npm:4.21.5"
+  dependencies:
+    caniuse-lite: ^1.0.30001449
+    electron-to-chromium: ^1.4.284
+    node-releases: ^2.0.8
+    update-browserslist-db: ^1.0.10
+  bin:
+    browserslist: cli.js
+  checksum: 9755986b22e73a6a1497fd8797aedd88e04270be33ce66ed5d85a1c8a798292a65e222b0f251bafa1c2522261e237d73b08b58689d4920a607e5a53d56dc4706
+  languageName: node
+  linkType: hard
+
 "buffer-from@npm:^1.0.0":
   version: 1.1.2
   resolution: "buffer-from@npm:1.1.2"
@@ -2666,6 +3132,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"buffer@npm:^6.0.3":
+  version: 6.0.3
+  resolution: "buffer@npm:6.0.3"
+  dependencies:
+    base64-js: ^1.3.1
+    ieee754: ^1.2.1
+  checksum: 5ad23293d9a731e4318e420025800b42bf0d264004c0286c8cc010af7a270c7a0f6522e84f54b9ad65cbd6db20b8badbfd8d2ebf4f80fa03dab093b89e68c3f9
+  languageName: node
+  linkType: hard
+
 "builtin-modules@npm:^3.1.0":
   version: 3.3.0
   resolution: "builtin-modules@npm:3.3.0"
@@ -2673,10 +3149,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cac@npm:^6.7.12":
-  version: 6.7.12
-  resolution: "cac@npm:6.7.12"
-  checksum: c0d4129eb30fc43449e9078ac37bb3b837aab6261236a6642a6fb9d839bb6a41e191e1f2776f87569535db07dcbf4937680419126215b4c17c9dba4351d1bd5e
+"cac@npm:^6.7.14":
+  version: 6.7.14
+  resolution: "cac@npm:6.7.14"
+  checksum: 45a2496a9443abbe7f52a49b22fbe51b1905eff46e03fd5e6c98e3f85077be3f8949685a1849b1a9cd2bc3e5567dfebcf64f01ce01847baf918f1b37c839791a
   languageName: node
   linkType: hard
 
@@ -2716,10 +3192,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"caniuse-lite@npm:^1.0.30001370, caniuse-lite@npm:^1.0.30001373":
+"caniuse-lite@npm:^1.0.30001370":
   version: 1.0.30001374
   resolution: "caniuse-lite@npm:1.0.30001374"
   checksum: a75656e971d7ef2af4d2f3529a4620ae1a45d09460601fbc34b26f6867f31bbca006f71d8840291c471a2f01fc1994044f319a5660241ffaf35a2d84535af442
+  languageName: node
+  linkType: hard
+
+"caniuse-lite@npm:^1.0.30001426, caniuse-lite@npm:^1.0.30001449":
+  version: 1.0.30001452
+  resolution: "caniuse-lite@npm:1.0.30001452"
+  checksum: de02aad7b71112409f30de53e8080bef0fe612ed95bba8b14fb830f59683e8caabc27bdd520563686965be77f2cb56e239e44b920144630b91d7fe9911ba8ad5
   languageName: node
   linkType: hard
 
@@ -2741,6 +3224,13 @@ __metadata:
     ansi-styles: ^4.1.0
     supports-color: ^7.1.0
   checksum: fe75c9d5c76a7a98d45495b91b2172fa3b7a09e0cc9370e5c8feb1c567b85c4288e2b3fded7cfdd7359ac28d6b3844feb8b82b8686842e93d23c827c417e83fc
+  languageName: node
+  linkType: hard
+
+"chalk@npm:^5.0.0":
+  version: 5.2.0
+  resolution: "chalk@npm:5.2.0"
+  checksum: 03d8060277de6cf2fd567dc25fcf770593eb5bb85f460ce443e49255a30ff1242edd0c90a06a03803b0466ff0687a939b41db1757bec987113e83de89a003caa
   languageName: node
   linkType: hard
 
@@ -2786,7 +3276,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cli-spinners@npm:^2.5.0":
+"cli-cursor@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "cli-cursor@npm:4.0.0"
+  dependencies:
+    restore-cursor: ^4.0.0
+  checksum: ab3f3ea2076e2176a1da29f9d64f72ec3efad51c0960898b56c8a17671365c26e67b735920530eaf7328d61f8bd41c27f46b9cf6e4e10fe2fa44b5e8c0e392cc
+  languageName: node
+  linkType: hard
+
+"cli-spinners@npm:^2.5.0, cli-spinners@npm:^2.6.1":
   version: 2.7.0
   resolution: "cli-spinners@npm:2.7.0"
   checksum: a9afaf73f58d1f951fb23742f503631b3cf513f43f4c7acb1b640100eb76bfa16efbcd1994d149ffc6603a6d75dd3d4a516a76f125f90dce437de9b16fd0ee6f
@@ -2999,6 +3498,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"electron-to-chromium@npm:^1.4.284":
+  version: 1.4.297
+  resolution: "electron-to-chromium@npm:1.4.297"
+  checksum: d5b83384c378cb22e023abd9ad566abfd573ea7a24109b992f034752bcf77602b67b5a20064a8810ee6bd4db17547d80fa7e30c3602f57a503950e8063491eb2
+  languageName: node
+  linkType: hard
+
 "emoji-regex@npm:^8.0.0":
   version: 8.0.0
   resolution: "emoji-regex@npm:8.0.0"
@@ -3087,217 +3593,80 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-android-64@npm:0.14.53":
-  version: 0.14.53
-  resolution: "esbuild-android-64@npm:0.14.53"
-  conditions: os=android & cpu=x64
-  languageName: node
-  linkType: hard
-
-"esbuild-android-arm64@npm:0.14.53":
-  version: 0.14.53
-  resolution: "esbuild-android-arm64@npm:0.14.53"
-  conditions: os=android & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"esbuild-darwin-64@npm:0.14.53":
-  version: 0.14.53
-  resolution: "esbuild-darwin-64@npm:0.14.53"
-  conditions: os=darwin & cpu=x64
-  languageName: node
-  linkType: hard
-
-"esbuild-darwin-arm64@npm:0.14.53":
-  version: 0.14.53
-  resolution: "esbuild-darwin-arm64@npm:0.14.53"
-  conditions: os=darwin & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"esbuild-freebsd-64@npm:0.14.53":
-  version: 0.14.53
-  resolution: "esbuild-freebsd-64@npm:0.14.53"
-  conditions: os=freebsd & cpu=x64
-  languageName: node
-  linkType: hard
-
-"esbuild-freebsd-arm64@npm:0.14.53":
-  version: 0.14.53
-  resolution: "esbuild-freebsd-arm64@npm:0.14.53"
-  conditions: os=freebsd & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"esbuild-linux-32@npm:0.14.53":
-  version: 0.14.53
-  resolution: "esbuild-linux-32@npm:0.14.53"
-  conditions: os=linux & cpu=ia32
-  languageName: node
-  linkType: hard
-
-"esbuild-linux-64@npm:0.14.53":
-  version: 0.14.53
-  resolution: "esbuild-linux-64@npm:0.14.53"
-  conditions: os=linux & cpu=x64
-  languageName: node
-  linkType: hard
-
-"esbuild-linux-arm64@npm:0.14.53":
-  version: 0.14.53
-  resolution: "esbuild-linux-arm64@npm:0.14.53"
-  conditions: os=linux & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"esbuild-linux-arm@npm:0.14.53":
-  version: 0.14.53
-  resolution: "esbuild-linux-arm@npm:0.14.53"
-  conditions: os=linux & cpu=arm
-  languageName: node
-  linkType: hard
-
-"esbuild-linux-mips64le@npm:0.14.53":
-  version: 0.14.53
-  resolution: "esbuild-linux-mips64le@npm:0.14.53"
-  conditions: os=linux & cpu=mips64el
-  languageName: node
-  linkType: hard
-
-"esbuild-linux-ppc64le@npm:0.14.53":
-  version: 0.14.53
-  resolution: "esbuild-linux-ppc64le@npm:0.14.53"
-  conditions: os=linux & cpu=ppc64
-  languageName: node
-  linkType: hard
-
-"esbuild-linux-riscv64@npm:0.14.53":
-  version: 0.14.53
-  resolution: "esbuild-linux-riscv64@npm:0.14.53"
-  conditions: os=linux & cpu=riscv64
-  languageName: node
-  linkType: hard
-
-"esbuild-linux-s390x@npm:0.14.53":
-  version: 0.14.53
-  resolution: "esbuild-linux-s390x@npm:0.14.53"
-  conditions: os=linux & cpu=s390x
-  languageName: node
-  linkType: hard
-
-"esbuild-netbsd-64@npm:0.14.53":
-  version: 0.14.53
-  resolution: "esbuild-netbsd-64@npm:0.14.53"
-  conditions: os=netbsd & cpu=x64
-  languageName: node
-  linkType: hard
-
-"esbuild-openbsd-64@npm:0.14.53":
-  version: 0.14.53
-  resolution: "esbuild-openbsd-64@npm:0.14.53"
-  conditions: os=openbsd & cpu=x64
-  languageName: node
-  linkType: hard
-
-"esbuild-sunos-64@npm:0.14.53":
-  version: 0.14.53
-  resolution: "esbuild-sunos-64@npm:0.14.53"
-  conditions: os=sunos & cpu=x64
-  languageName: node
-  linkType: hard
-
-"esbuild-windows-32@npm:0.14.53":
-  version: 0.14.53
-  resolution: "esbuild-windows-32@npm:0.14.53"
-  conditions: os=win32 & cpu=ia32
-  languageName: node
-  linkType: hard
-
-"esbuild-windows-64@npm:0.14.53":
-  version: 0.14.53
-  resolution: "esbuild-windows-64@npm:0.14.53"
-  conditions: os=win32 & cpu=x64
-  languageName: node
-  linkType: hard
-
-"esbuild-windows-arm64@npm:0.14.53":
-  version: 0.14.53
-  resolution: "esbuild-windows-arm64@npm:0.14.53"
-  conditions: os=win32 & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"esbuild@npm:^0.14.27, esbuild@npm:^0.14.49":
-  version: 0.14.53
-  resolution: "esbuild@npm:0.14.53"
+"esbuild@npm:^0.16.12, esbuild@npm:^0.16.3":
+  version: 0.16.17
+  resolution: "esbuild@npm:0.16.17"
   dependencies:
-    "@esbuild/linux-loong64": 0.14.53
-    esbuild-android-64: 0.14.53
-    esbuild-android-arm64: 0.14.53
-    esbuild-darwin-64: 0.14.53
-    esbuild-darwin-arm64: 0.14.53
-    esbuild-freebsd-64: 0.14.53
-    esbuild-freebsd-arm64: 0.14.53
-    esbuild-linux-32: 0.14.53
-    esbuild-linux-64: 0.14.53
-    esbuild-linux-arm: 0.14.53
-    esbuild-linux-arm64: 0.14.53
-    esbuild-linux-mips64le: 0.14.53
-    esbuild-linux-ppc64le: 0.14.53
-    esbuild-linux-riscv64: 0.14.53
-    esbuild-linux-s390x: 0.14.53
-    esbuild-netbsd-64: 0.14.53
-    esbuild-openbsd-64: 0.14.53
-    esbuild-sunos-64: 0.14.53
-    esbuild-windows-32: 0.14.53
-    esbuild-windows-64: 0.14.53
-    esbuild-windows-arm64: 0.14.53
+    "@esbuild/android-arm": 0.16.17
+    "@esbuild/android-arm64": 0.16.17
+    "@esbuild/android-x64": 0.16.17
+    "@esbuild/darwin-arm64": 0.16.17
+    "@esbuild/darwin-x64": 0.16.17
+    "@esbuild/freebsd-arm64": 0.16.17
+    "@esbuild/freebsd-x64": 0.16.17
+    "@esbuild/linux-arm": 0.16.17
+    "@esbuild/linux-arm64": 0.16.17
+    "@esbuild/linux-ia32": 0.16.17
+    "@esbuild/linux-loong64": 0.16.17
+    "@esbuild/linux-mips64el": 0.16.17
+    "@esbuild/linux-ppc64": 0.16.17
+    "@esbuild/linux-riscv64": 0.16.17
+    "@esbuild/linux-s390x": 0.16.17
+    "@esbuild/linux-x64": 0.16.17
+    "@esbuild/netbsd-x64": 0.16.17
+    "@esbuild/openbsd-x64": 0.16.17
+    "@esbuild/sunos-x64": 0.16.17
+    "@esbuild/win32-arm64": 0.16.17
+    "@esbuild/win32-ia32": 0.16.17
+    "@esbuild/win32-x64": 0.16.17
   dependenciesMeta:
+    "@esbuild/android-arm":
+      optional: true
+    "@esbuild/android-arm64":
+      optional: true
+    "@esbuild/android-x64":
+      optional: true
+    "@esbuild/darwin-arm64":
+      optional: true
+    "@esbuild/darwin-x64":
+      optional: true
+    "@esbuild/freebsd-arm64":
+      optional: true
+    "@esbuild/freebsd-x64":
+      optional: true
+    "@esbuild/linux-arm":
+      optional: true
+    "@esbuild/linux-arm64":
+      optional: true
+    "@esbuild/linux-ia32":
+      optional: true
     "@esbuild/linux-loong64":
       optional: true
-    esbuild-android-64:
+    "@esbuild/linux-mips64el":
       optional: true
-    esbuild-android-arm64:
+    "@esbuild/linux-ppc64":
       optional: true
-    esbuild-darwin-64:
+    "@esbuild/linux-riscv64":
       optional: true
-    esbuild-darwin-arm64:
+    "@esbuild/linux-s390x":
       optional: true
-    esbuild-freebsd-64:
+    "@esbuild/linux-x64":
       optional: true
-    esbuild-freebsd-arm64:
+    "@esbuild/netbsd-x64":
       optional: true
-    esbuild-linux-32:
+    "@esbuild/openbsd-x64":
       optional: true
-    esbuild-linux-64:
+    "@esbuild/sunos-x64":
       optional: true
-    esbuild-linux-arm:
+    "@esbuild/win32-arm64":
       optional: true
-    esbuild-linux-arm64:
+    "@esbuild/win32-ia32":
       optional: true
-    esbuild-linux-mips64le:
-      optional: true
-    esbuild-linux-ppc64le:
-      optional: true
-    esbuild-linux-riscv64:
-      optional: true
-    esbuild-linux-s390x:
-      optional: true
-    esbuild-netbsd-64:
-      optional: true
-    esbuild-openbsd-64:
-      optional: true
-    esbuild-sunos-64:
-      optional: true
-    esbuild-windows-32:
-      optional: true
-    esbuild-windows-64:
-      optional: true
-    esbuild-windows-arm64:
+    "@esbuild/win32-x64":
       optional: true
   bin:
     esbuild: bin/esbuild
-  checksum: cd62d3bc805c6c2ff2cfe62c2fbe6a6d617783d5095167df861be7ddba464281f719a5ded2e940ba21838abf58cce8259daffa08667515c4396ff7bf683f5b70
+  checksum: 4c2cc609ecfb426554bc3f75beb92d89eb2d0c515cfceebaa36c7599d7dcaab7056b70f6d6b51e72b45951ddf9021ee28e356cf205f8e42cc055d522312ea30c
   languageName: node
   linkType: hard
 
@@ -3360,6 +3729,23 @@ __metadata:
     signal-exit: ^3.0.3
     strip-final-newline: ^2.0.0
   checksum: fba9022c8c8c15ed862847e94c252b3d946036d7547af310e344a527e59021fd8b6bb0723883ea87044dc4f0201f949046993124a42ccb0855cae5bf8c786343
+  languageName: node
+  linkType: hard
+
+"execa@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "execa@npm:6.1.0"
+  dependencies:
+    cross-spawn: ^7.0.3
+    get-stream: ^6.0.1
+    human-signals: ^3.0.1
+    is-stream: ^3.0.0
+    merge-stream: ^2.0.0
+    npm-run-path: ^5.1.0
+    onetime: ^6.0.0
+    signal-exit: ^3.0.7
+    strip-final-newline: ^3.0.0
+  checksum: 1a4af799839134f5c72eb63d525b87304c1114a63aa71676c91d57ccef2e26f2f53e14c11384ab11c4ec479be1efa83d11c8190e00040355c2c5c3364327fa8e
   languageName: node
   linkType: hard
 
@@ -3454,6 +3840,17 @@ __metadata:
     jsonfile: ^6.0.1
     universalify: ^2.0.0
   checksum: dc94ab37096f813cc3ca12f0f1b5ad6744dfed9ed21e953d72530d103cea193c2f81584a39e9dee1bea36de5ee66805678c0dddc048e8af1427ac19c00fffc50
+  languageName: node
+  linkType: hard
+
+"fs-extra@npm:^11.1.0":
+  version: 11.1.0
+  resolution: "fs-extra@npm:11.1.0"
+  dependencies:
+    graceful-fs: ^4.2.0
+    jsonfile: ^6.0.1
+    universalify: ^2.0.0
+  checksum: 5ca476103fa1f5ff4a9b3c4f331548f8a3c1881edaae323a4415d3153b5dc11dc6a981c8d1dd93eec8367ceee27b53f8bd27eecbbf66ffcdd04927510c171e7f
   languageName: node
   linkType: hard
 
@@ -3571,7 +3968,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-stream@npm:^6.0.0":
+"get-stream@npm:^6.0.0, get-stream@npm:^6.0.1":
   version: 6.0.1
   resolution: "get-stream@npm:6.0.1"
   checksum: e04ecece32c92eebf5b8c940f51468cd53554dcbb0ea725b2748be583c9523d00128137966afce410b9b051eb2ef16d657cd2b120ca8edafcf5a65e81af63cad
@@ -3631,7 +4028,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"globby@npm:13.1.3":
+"globby@npm:13.1.3, globby@npm:^13.1.3":
   version: 13.1.3
   resolution: "globby@npm:13.1.3"
   dependencies:
@@ -3781,6 +4178,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"human-signals@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "human-signals@npm:3.0.1"
+  checksum: f252a7769c8094a5c9dc6772816bdb417b188820b04c8b42d0fc468e03a0ba905b1dd07afabe9385cc83504af1ccc2b985cd1e4aeeeb8e0029896c5af2e6f354
+  languageName: node
+  linkType: hard
+
 "humanize-ms@npm:^1.2.1":
   version: 1.2.1
   resolution: "humanize-ms@npm:1.2.1"
@@ -3806,7 +4210,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ieee754@npm:^1.1.13":
+"ieee754@npm:^1.1.13, ieee754@npm:^1.2.1":
   version: 1.2.1
   resolution: "ieee754@npm:1.2.1"
   checksum: 5144c0c9815e54ada181d80a0b810221a253562422e7c6c3a60b1901154184f49326ec239d618c416c1c5945a2e197107aee8d986a3dd836b53dffefd99b5e7e
@@ -3821,9 +4225,9 @@ __metadata:
   linkType: hard
 
 "immutable@npm:^4.0.0":
-  version: 4.1.0
-  resolution: "immutable@npm:4.1.0"
-  checksum: b9bc1f14fb18eb382d48339c064b24a1f97ae4cf43102e0906c0a6e186a27afcd18b55ca4a0b63c98eefb58143e2b5ebc7755a5fb4da4a7ad84b7a6096ac5b13
+  version: 4.2.4
+  resolution: "immutable@npm:4.2.4"
+  checksum: 3be84eded37b05e65cad57bfba630bc1bf170c498b7472144bc02d2650cc9baef79daf03574a9c2e41d195ebb55a1c12c9b312f41ee324b653927b24ad8bcaa7
   languageName: node
   linkType: hard
 
@@ -3973,6 +4377,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-interactive@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "is-interactive@npm:2.0.0"
+  checksum: e8d52ad490bed7ae665032c7675ec07732bbfe25808b0efbc4d5a76b1a1f01c165f332775c63e25e9a03d319ebb6b24f571a9e902669fc1e40b0a60b5be6e26c
+  languageName: node
+  linkType: hard
+
 "is-lambda@npm:^1.0.1":
   version: 1.0.1
   resolution: "is-lambda@npm:1.0.1"
@@ -4050,6 +4461,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-stream@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "is-stream@npm:3.0.0"
+  checksum: 172093fe99119ffd07611ab6d1bcccfe8bc4aa80d864b15f43e63e54b7abc71e779acd69afdb854c4e2a67fdc16ae710e370eda40088d1cfc956a50ed82d8f16
+  languageName: node
+  linkType: hard
+
 "is-string@npm:^1.0.5, is-string@npm:^1.0.7":
   version: 1.0.7
   resolution: "is-string@npm:1.0.7"
@@ -4072,6 +4490,13 @@ __metadata:
   version: 0.1.0
   resolution: "is-unicode-supported@npm:0.1.0"
   checksum: a2aab86ee7712f5c2f999180daaba5f361bdad1efadc9610ff5b8ab5495b86e4f627839d085c6530363c6d6d4ecbde340fb8e54bdb83da4ba8e0865ed5513c52
+  languageName: node
+  linkType: hard
+
+"is-unicode-supported@npm:^1.1.0":
+  version: 1.3.0
+  resolution: "is-unicode-supported@npm:1.3.0"
+  checksum: 20a1fc161afafaf49243551a5ac33b6c4cf0bbcce369fcd8f2951fbdd000c30698ce320de3ee6830497310a8f41880f8066d440aa3eb0a853e2aa4836dd89abc
   languageName: node
   linkType: hard
 
@@ -4210,6 +4635,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lilconfig@npm:^2.0.5":
+  version: 2.0.6
+  resolution: "lilconfig@npm:2.0.6"
+  checksum: 40a3cd72f103b1be5975f2ac1850810b61d4053e20ab09be8d3aeddfe042187e1ba70b4651a7e70f95efa1642e7dc8b2ae395b317b7d7753b241b43cef7c0f7d
+  languageName: node
+  linkType: hard
+
 "linkify-it@npm:^4.0.1":
   version: 4.0.1
   resolution: "linkify-it@npm:4.0.1"
@@ -4247,6 +4679,16 @@ __metadata:
     chalk: ^4.1.0
     is-unicode-supported: ^0.1.0
   checksum: fce1497b3135a0198803f9f07464165e9eb83ed02ceb2273930a6f8a508951178d8cf4f0378e9d28300a2ed2bc49050995d2bd5f53ab716bb15ac84d58c6ef74
+  languageName: node
+  linkType: hard
+
+"log-symbols@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "log-symbols@npm:5.1.0"
+  dependencies:
+    chalk: ^5.0.0
+    is-unicode-supported: ^1.1.0
+  checksum: 7291b6e7f1b3df6865bdaeb9b59605c832668ac2fa0965c63b1e7dd3700349aec09c1d7d40c368d5041ff58b7f89461a56e4009471921301af7b3609cbff9a29
   languageName: node
   linkType: hard
 
@@ -4306,6 +4748,16 @@ __metadata:
     "@types/markdown-it": "*"
     markdown-it: "*"
   checksum: bde310d0202450a228662921df9d9c2e95b3c5762512e8eed1d472fcc812fb20e6b4e98480cda88c8b56b0baf34ac70d6bf8404309c5a2321ebe62da43cd6fe6
+  languageName: node
+  linkType: hard
+
+"markdown-it-anchor@npm:^8.6.6":
+  version: 8.6.6
+  resolution: "markdown-it-anchor@npm:8.6.6"
+  peerDependencies:
+    "@types/markdown-it": "*"
+    markdown-it: "*"
+  checksum: d67044f132cd94728227e065b2a82063a05ac5fb82a991c190fe48ac5ab308ed85f49a28e859bcf203e882af814902e67dd69724f6761c61709834b075cc6f95
   languageName: node
   linkType: hard
 
@@ -4381,10 +4833,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"medium-zoom@npm:^1.0.6":
-  version: 1.0.6
-  resolution: "medium-zoom@npm:1.0.6"
-  checksum: 728b9f661262fd084da26f401ffe9bf98afc6d14ad93d4bfb08b95d32f9c4494a97dc8cb3a62353e8d350dc09c84a3f6f686a0fec321bfb609e5ba5e24bdb9d2
+"medium-zoom@npm:^1.0.8":
+  version: 1.0.8
+  resolution: "medium-zoom@npm:1.0.8"
+  checksum: b65be8546ab255936271e15a17524677808774140199e58c4dc0bae131b504a13e481c4f483ca8a862d32636dd4996bd7ed0a005c1f6213c3c764aa03fbbc48e
   languageName: node
   linkType: hard
 
@@ -4416,6 +4868,13 @@ __metadata:
   version: 2.1.0
   resolution: "mimic-fn@npm:2.1.0"
   checksum: d2421a3444848ce7f84bd49115ddacff29c15745db73f54041edc906c14b131a38d05298dae3081667627a59b2eb1ca4b436ff2e1b80f69679522410418b478a
+  languageName: node
+  linkType: hard
+
+"mimic-fn@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "mimic-fn@npm:4.0.0"
+  checksum: 995dcece15ee29aa16e188de6633d43a3db4611bcf93620e7e62109ec41c79c0f34277165b8ce5e361205049766e371851264c21ac64ca35499acb5421c2ba56
   languageName: node
   linkType: hard
 
@@ -4580,6 +5039,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"node-releases@npm:^2.0.8":
+  version: 2.0.10
+  resolution: "node-releases@npm:2.0.10"
+  checksum: d784ecde25696a15d449c4433077f5cce620ed30a1656c4abf31282bfc691a70d9618bae6868d247a67914d1be5cc4fde22f65a05f4398cdfb92e0fc83cadfbc
+  languageName: node
+  linkType: hard
+
 "nopt@npm:^5.0.0":
   version: 5.0.0
   resolution: "nopt@npm:5.0.0"
@@ -4611,6 +5077,15 @@ __metadata:
   dependencies:
     path-key: ^3.0.0
   checksum: 5374c0cea4b0bbfdfae62da7bbdf1e1558d338335f4cacf2515c282ff358ff27b2ecb91ffa5330a8b14390ac66a1e146e10700440c1ab868208430f56b5f4d23
+  languageName: node
+  linkType: hard
+
+"npm-run-path@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "npm-run-path@npm:5.1.0"
+  dependencies:
+    path-key: ^4.0.0
+  checksum: dc184eb5ec239d6a2b990b43236845332ef12f4e0beaa9701de724aa797fe40b6bbd0157fb7639d24d3ab13f5d5cf22d223a19c6300846b8126f335f788bee66
   languageName: node
   linkType: hard
 
@@ -4670,6 +5145,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"onetime@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "onetime@npm:6.0.0"
+  dependencies:
+    mimic-fn: ^4.0.0
+  checksum: 0846ce78e440841335d4e9182ef69d5762e9f38aa7499b19f42ea1c4cd40f0b4446094c455c713f9adac3f4ae86f613bb5e30c99e52652764d06a89f709b3788
+  languageName: node
+  linkType: hard
+
 "ora@npm:^5.4.1":
   version: 5.4.1
   resolution: "ora@npm:5.4.1"
@@ -4684,6 +5168,23 @@ __metadata:
     strip-ansi: ^6.0.0
     wcwidth: ^1.0.1
   checksum: 28d476ee6c1049d68368c0dc922e7225e3b5600c3ede88fade8052837f9ed342625fdaa84a6209302587c8ddd9b664f71f0759833cbdb3a4cf81344057e63c63
+  languageName: node
+  linkType: hard
+
+"ora@npm:^6.1.2":
+  version: 6.1.2
+  resolution: "ora@npm:6.1.2"
+  dependencies:
+    bl: ^5.0.0
+    chalk: ^5.0.0
+    cli-cursor: ^4.0.0
+    cli-spinners: ^2.6.1
+    is-interactive: ^2.0.0
+    is-unicode-supported: ^1.1.0
+    log-symbols: ^5.1.0
+    strip-ansi: ^7.0.1
+    wcwidth: ^1.0.1
+  checksum: d5af3d67ad7affcf3029ffe3ef547f3335fb72abdc382040ae8bd75ad5c629f5d165ed9e398fd4fb08100701eafbec34bb9dc3f29e919f6f75c443290faa1db2
   languageName: node
   linkType: hard
 
@@ -4707,6 +5208,13 @@ __metadata:
   version: 3.1.1
   resolution: "path-key@npm:3.1.1"
   checksum: 55cd7a9dd4b343412a8386a743f9c746ef196e57c823d90ca3ab917f90ab9f13dd0ded27252ba49dbdfcab2b091d998bc446f6220cd3cea65db407502a740020
+  languageName: node
+  linkType: hard
+
+"path-key@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "path-key@npm:4.0.0"
+  checksum: 8e6c314ae6d16b83e93032c61020129f6f4484590a777eed709c4a01b50e498822b00f76ceaf94bc64dbd90b327df56ceadce27da3d83393790f1219e07721d7
   languageName: node
   linkType: hard
 
@@ -4738,6 +5246,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"postcss-load-config@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "postcss-load-config@npm:4.0.1"
+  dependencies:
+    lilconfig: ^2.0.5
+    yaml: ^2.1.1
+  peerDependencies:
+    postcss: ">=8.0.9"
+    ts-node: ">=9.0.0"
+  peerDependenciesMeta:
+    postcss:
+      optional: true
+    ts-node:
+      optional: true
+  checksum: b61f890499ed7dcda1e36c20a9582b17d745bad5e2b2c7bc96942465e406bc43ae03f270c08e60d1e29dab1ee50cb26970b5eb20c9aae30e066e20bd607ae4e4
+  languageName: node
+  linkType: hard
+
 "postcss-value-parser@npm:^4.2.0":
   version: 4.2.0
   resolution: "postcss-value-parser@npm:4.2.0"
@@ -4745,7 +5271,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.1.10, postcss@npm:^8.4.13, postcss@npm:^8.4.14":
+"postcss@npm:^8.1.10":
   version: 8.4.14
   resolution: "postcss@npm:8.4.14"
   dependencies:
@@ -4753,6 +5279,17 @@ __metadata:
     picocolors: ^1.0.0
     source-map-js: ^1.0.2
   checksum: fe58766ff32e4becf65a7d57678995cfd239df6deed2fe0557f038b47c94e4132e7e5f68b5aa820c13adfec32e523b693efaeb65798efb995ce49ccd83953816
+  languageName: node
+  linkType: hard
+
+"postcss@npm:^8.4.20":
+  version: 8.4.21
+  resolution: "postcss@npm:8.4.21"
+  dependencies:
+    nanoid: ^3.3.4
+    picocolors: ^1.0.0
+    source-map-js: ^1.0.2
+  checksum: e39ac60ccd1542d4f9d93d894048aac0d686b3bb38e927d8386005718e6793dbbb46930f0a523fe382f1bbd843c6d980aaea791252bf5e176180e5a4336d9679
   languageName: node
   linkType: hard
 
@@ -4770,10 +5307,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prismjs@npm:^1.28.0":
-  version: 1.28.0
-  resolution: "prismjs@npm:1.28.0"
-  checksum: bde93fb2beb45b7243219fc53855f59ee54b3fa179f315e8f9d66244d756ef984462e10561bbdc6713d3d7e051852472d7c284f5794a8791eeaefea2fb910b16
+"prismjs@npm:^1.29.0":
+  version: 1.29.0
+  resolution: "prismjs@npm:1.29.0"
+  checksum: 007a8869d4456ff8049dc59404e32d5666a07d99c3b0e30a18bd3b7676dfa07d1daae9d0f407f20983865fd8da56de91d09cb08e6aa61f5bc420a27c0beeaf93
   languageName: node
   linkType: hard
 
@@ -4926,7 +5463,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@npm:^1.14.2, resolve@npm:^1.19.0, resolve@npm:^1.22.0":
+"resolve@npm:^1.14.2, resolve@npm:^1.19.0, resolve@npm:^1.22.1":
   version: 1.22.1
   resolution: "resolve@npm:1.22.1"
   dependencies:
@@ -4939,7 +5476,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@patch:resolve@^1.14.2#~builtin<compat/resolve>, resolve@patch:resolve@^1.19.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.22.0#~builtin<compat/resolve>":
+"resolve@patch:resolve@^1.14.2#~builtin<compat/resolve>, resolve@patch:resolve@^1.19.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.22.1#~builtin<compat/resolve>":
   version: 1.22.1
   resolution: "resolve@patch:resolve@npm%3A1.22.1#~builtin<compat/resolve>::version=1.22.1&hash=c3c19d"
   dependencies:
@@ -4959,6 +5496,16 @@ __metadata:
     onetime: ^5.1.0
     signal-exit: ^3.0.2
   checksum: f877dd8741796b909f2a82454ec111afb84eb45890eb49ac947d87991379406b3b83ff9673a46012fca0d7844bb989f45cc5b788254cf1a39b6b5a9659de0630
+  languageName: node
+  linkType: hard
+
+"restore-cursor@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "restore-cursor@npm:4.0.0"
+  dependencies:
+    onetime: ^5.1.0
+    signal-exit: ^3.0.2
+  checksum: 5b675c5a59763bf26e604289eab35711525f11388d77f409453904e1e69c0d37ae5889295706b2c81d23bd780165084d040f9b68fffc32cc921519031c4fa4af
   languageName: node
   linkType: hard
 
@@ -5001,7 +5548,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rollup@npm:^2.43.1, rollup@npm:^2.59.0, rollup@npm:^2.76.0":
+"rollup@npm:^2.43.1":
   version: 2.77.2
   resolution: "rollup@npm:2.77.2"
   dependencies:
@@ -5012,6 +5559,20 @@ __metadata:
   bin:
     rollup: dist/bin/rollup
   checksum: 5a84fb98a6f858906bceba091430442f6c1f362b07c5fa9123b708f87e39f52640e34a189cd9a1776ceae61300055c78ba648205fa03188451539ebeb19797df
+  languageName: node
+  linkType: hard
+
+"rollup@npm:^3.7.0, rollup@npm:^3.9.0":
+  version: 3.15.0
+  resolution: "rollup@npm:3.15.0"
+  dependencies:
+    fsevents: ~2.3.2
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  bin:
+    rollup: dist/bin/rollup
+  checksum: 1a75b09503f705b594dcfebf65b9e1ca4536e3facdf5716e10d4272697b4bb7e6bd8ab35be1b3fe1271f864d4c4a75d012bd77cbe7a55579d5138258b9e85c23
   languageName: node
   linkType: hard
 
@@ -5045,16 +5606,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sass@npm:^1.53.0":
-  version: 1.54.3
-  resolution: "sass@npm:1.54.3"
+"sass@npm:^1.57.1":
+  version: 1.58.1
+  resolution: "sass@npm:1.58.1"
   dependencies:
     chokidar: ">=3.0.0 <4.0.0"
     immutable: ^4.0.0
     source-map-js: ">=0.6.2 <2.0.0"
   bin:
     sass: sass.js
-  checksum: 9b405f602c0dcdad85e7f216cfa5ca9dfe3f7ded7b3928817cfe8dbfde0cd27b70f4cff724e229b233b3f51a06e71d3fcbbd7d3a0ff92b3e40ac57bc05b90b48
+  checksum: ff079887d906b5c0dde99084d14ac36336d238c0c07935ff6381bad68f05de212c1ff12657ac1e8a0533523cd7a393126facdc2508d758e7d5700344a0e6ea51
   languageName: node
   linkType: hard
 
@@ -5323,6 +5884,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"strip-ansi@npm:^7.0.1":
+  version: 7.0.1
+  resolution: "strip-ansi@npm:7.0.1"
+  dependencies:
+    ansi-regex: ^6.0.1
+  checksum: 257f78fa433520e7f9897722731d78599cb3fce29ff26a20a5e12ba4957463b50a01136f37c43707f4951817a75e90820174853d6ccc240997adc5df8f966039
+  languageName: node
+  linkType: hard
+
 "strip-bom-string@npm:^1.0.0":
   version: 1.0.0
   resolution: "strip-bom-string@npm:1.0.0"
@@ -5341,6 +5911,13 @@ __metadata:
   version: 2.0.0
   resolution: "strip-final-newline@npm:2.0.0"
   checksum: 69412b5e25731e1938184b5d489c32e340605bb611d6140344abc3421b7f3c6f9984b21dff296dfcf056681b82caa3bb4cc996a965ce37bcfad663e92eae9c64
+  languageName: node
+  linkType: hard
+
+"strip-final-newline@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "strip-final-newline@npm:3.0.0"
+  checksum: 23ee263adfa2070cd0f23d1ac14e2ed2f000c9b44229aec9c799f1367ec001478469560abefd00c5c99ee6f0b31c137d53ec6029c53e9f32a93804e18c201050
   languageName: node
   linkType: hard
 
@@ -5560,6 +6137,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"update-browserslist-db@npm:^1.0.10":
+  version: 1.0.10
+  resolution: "update-browserslist-db@npm:1.0.10"
+  dependencies:
+    escalade: ^3.1.1
+    picocolors: ^1.0.0
+  peerDependencies:
+    browserslist: ">= 4.21.0"
+  bin:
+    browserslist-lint: cli.js
+  checksum: 12db73b4f63029ac407b153732e7cd69a1ea8206c9100b482b7d12859cd3cd0bc59c602d7ae31e652706189f1acb90d42c53ab24a5ba563ed13aebdddc5561a0
+  languageName: node
+  linkType: hard
+
 "update-browserslist-db@npm:^1.0.5":
   version: 1.0.5
   resolution: "update-browserslist-db@npm:1.0.5"
@@ -5590,38 +6181,47 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite@npm:~2.9.14":
-  version: 2.9.14
-  resolution: "vite@npm:2.9.14"
+"vite@npm:~4.0.3":
+  version: 4.0.4
+  resolution: "vite@npm:4.0.4"
   dependencies:
-    esbuild: ^0.14.27
+    esbuild: ^0.16.3
     fsevents: ~2.3.2
-    postcss: ^8.4.13
-    resolve: ^1.22.0
-    rollup: ^2.59.0
+    postcss: ^8.4.20
+    resolve: ^1.22.1
+    rollup: ^3.7.0
   peerDependencies:
+    "@types/node": ">= 14"
     less: "*"
     sass: "*"
     stylus: "*"
+    sugarss: "*"
+    terser: ^5.4.0
   dependenciesMeta:
     fsevents:
       optional: true
   peerDependenciesMeta:
+    "@types/node":
+      optional: true
     less:
       optional: true
     sass:
       optional: true
     stylus:
       optional: true
+    sugarss:
+      optional: true
+    terser:
+      optional: true
   bin:
     vite: bin/vite.js
-  checksum: f78b54f58482ea97d385e36873ae1aa4744c5e467c1d6d4e0835bd55494d2d8f6ce763f17c241c66104be687d5ee535b8e1e96c14210c9ba0c343fe78c58f694
+  checksum: eb86c8cdfe8dcb6644005486b31cb60bc596f2aa683cb194abb5c0afca7c2a5dfdb02bbc7f83f419ad170227ac9c3b898f4406a6d1433105fb61d79d78e47d52
   languageName: node
   linkType: hard
 
 "vue-demi@npm:*":
-  version: 0.13.6
-  resolution: "vue-demi@npm:0.13.6"
+  version: 0.13.11
+  resolution: "vue-demi@npm:0.13.11"
   peerDependencies:
     "@vue/composition-api": ^1.0.0-rc.1
     vue: ^3.0.0-0 || ^2.6.0
@@ -5631,7 +6231,7 @@ __metadata:
   bin:
     vue-demi-fix: bin/vue-demi-fix.js
     vue-demi-switch: bin/vue-demi-switch.js
-  checksum: 7712b1f8edad902a8ea99ac307f9dc276ca13cb4394fdc6753c27c32f16e5f4a6d3acaa752bf24d73be0ea972552ad7da4c61314b046fbc248bd9aa26afe2e59
+  checksum: 0fbe9bf8ab7fe498ffa2bbd0cfc8f6f43a6bbaa5eda3e20ef1b70dca7c8b0ddb216a7ff2f632b694fe0735805638975abb441c621ec0bd2e6d4656353f316c15
   languageName: node
   linkType: hard
 
@@ -5643,6 +6243,17 @@ __metadata:
   peerDependencies:
     vue: ^3.2.0
   checksum: 92a827a05e3afd5cc6ff6a4d033abaefae098b60e4d128b402bebb88473ad8ca485e675a6f7df2a5598ba4a8a23a2652c0f7c55c2c57c4ac433ce75fb4672222
+  languageName: node
+  linkType: hard
+
+"vue-router@npm:^4.1.6":
+  version: 4.1.6
+  resolution: "vue-router@npm:4.1.6"
+  dependencies:
+    "@vue/devtools-api": ^6.4.5
+  peerDependencies:
+    vue: ^3.2.0
+  checksum: c7f0156ac03a9561d110f5ff778121eee7c8c154be6ec5064558ba22ab5237db36f29ffffc95cc16d692cc68a26df0c434f395401c0e3b48f782c7bed51391c6
   languageName: node
   linkType: hard
 
@@ -5659,32 +6270,45 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vuepress-vite@npm:2.0.0-beta.49":
-  version: 2.0.0-beta.49
-  resolution: "vuepress-vite@npm:2.0.0-beta.49"
+"vue@npm:^3.2.45":
+  version: 3.2.47
+  resolution: "vue@npm:3.2.47"
   dependencies:
-    "@vuepress/bundler-vite": 2.0.0-beta.49
-    "@vuepress/cli": 2.0.0-beta.49
-    "@vuepress/core": 2.0.0-beta.49
-    "@vuepress/theme-default": 2.0.0-beta.49
-  peerDependencies:
-    "@vuepress/client": ^2.0.0-beta.42
-    vue: ^3.2.36
-  bin:
-    vuepress: bin/vuepress.js
-    vuepress-vite: bin/vuepress.js
-  checksum: 6b82cb16fb89690b8c5b808a31d777a761918079341a89cf8e7b83a6e83356c0619073d19e52629e4acaf711610121d46197c18f1cda1d5b8ea854026f2a8f2e
+    "@vue/compiler-dom": 3.2.47
+    "@vue/compiler-sfc": 3.2.47
+    "@vue/runtime-dom": 3.2.47
+    "@vue/server-renderer": 3.2.47
+    "@vue/shared": 3.2.47
+  checksum: 3b586f61fd2cdfdd24459a946a2831c0f164056993cc005badde4fea10d53e430f1cedf1b62d52a6992b58fe656fc5fc67b32f594a2832dfe440c6db46d6f158
   languageName: node
   linkType: hard
 
-"vuepress@npm:^2.0.0-beta.48":
-  version: 2.0.0-beta.49
-  resolution: "vuepress@npm:2.0.0-beta.49"
+"vuepress-vite@npm:2.0.0-beta.60":
+  version: 2.0.0-beta.60
+  resolution: "vuepress-vite@npm:2.0.0-beta.60"
   dependencies:
-    vuepress-vite: 2.0.0-beta.49
+    "@vuepress/bundler-vite": 2.0.0-beta.60
+    "@vuepress/cli": 2.0.0-beta.60
+    "@vuepress/core": 2.0.0-beta.60
+    "@vuepress/theme-default": 2.0.0-beta.60
+  peerDependencies:
+    "@vuepress/client": 2.0.0-beta.60
+    vue: ^3.2.45
   bin:
     vuepress: bin/vuepress.js
-  checksum: d53854c75efee6505774d79aeee1179ab051c3808e2065b24a8335137ec21fa95c1ac8f8100f56ed27f0c7017ef6a3b9d48a878d3433e262515a066f7af924ea
+    vuepress-vite: bin/vuepress.js
+  checksum: 288123ff07f598e6dd083c6e23c3551e777e87b985d9173d71d759b72663023002d63fbfac57f68ac1598bf7b7fe9f08bda51ba116fa2fb0704c6c370e01857f
+  languageName: node
+  linkType: hard
+
+"vuepress@npm:2.0.0-beta.60":
+  version: 2.0.0-beta.60
+  resolution: "vuepress@npm:2.0.0-beta.60"
+  dependencies:
+    vuepress-vite: 2.0.0-beta.60
+  bin:
+    vuepress: bin/vuepress.js
+  checksum: 2df3924c2a6d6ca84a77f36dd9ff0ea90e6135dccb726d8d50c1a0465357b2479ed77fb6a97256304fdb81512b5f1d569a54d625656eec69d3ac2f6b6b982f3a
   languageName: node
   linkType: hard
 
@@ -5952,7 +6576,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yaml@npm:2.2.1":
+"yaml@npm:2.2.1, yaml@npm:^2.1.1":
   version: 2.2.1
   resolution: "yaml@npm:2.2.1"
   checksum: 84f68cbe462d5da4e7ded4a8bded949ffa912bc264472e5a684c3d45b22d8f73a3019963a32164023bdf3d83cfb6f5b58ff7b2b10ef5b717c630f40bd6369a23

--- a/yarn.lock
+++ b/yarn.lock
@@ -2878,14 +2878,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"caniuse-lite@npm:^1.0.30001370":
-  version: 1.0.30001374
-  resolution: "caniuse-lite@npm:1.0.30001374"
-  checksum: a75656e971d7ef2af4d2f3529a4620ae1a45d09460601fbc34b26f6867f31bbca006f71d8840291c471a2f01fc1994044f319a5660241ffaf35a2d84535af442
-  languageName: node
-  linkType: hard
-
-"caniuse-lite@npm:^1.0.30001426, caniuse-lite@npm:^1.0.30001449":
+"caniuse-lite@npm:^1.0.30001370, caniuse-lite@npm:^1.0.30001426, caniuse-lite@npm:^1.0.30001449":
   version: 1.0.30001452
   resolution: "caniuse-lite@npm:1.0.30001452"
   checksum: de02aad7b71112409f30de53e8080bef0fe612ed95bba8b14fb830f59683e8caabc27bdd520563686965be77f2cb56e239e44b920144630b91d7fe9911ba8ad5

--- a/yarn.lock
+++ b/yarn.lock
@@ -2439,14 +2439,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vuepress/plugin-google-analytics@npm:^2.0.0-beta.48":
-  version: 2.0.0-beta.50-pre.1
-  resolution: "@vuepress/plugin-google-analytics@npm:2.0.0-beta.50-pre.1"
+"@vuepress/plugin-google-analytics@npm:2.0.0-beta.60":
+  version: 2.0.0-beta.60
+  resolution: "@vuepress/plugin-google-analytics@npm:2.0.0-beta.60"
   dependencies:
-    "@vuepress/client": 2.0.0-beta.50-pre.1
-    "@vuepress/core": 2.0.0-beta.50-pre.1
-    "@vuepress/utils": 2.0.0-beta.50-pre.1
-  checksum: 65fc67fa5b3a27e8a198c592d272c773700955281a3fa78d9a711876dc56a2920186b005c594663a474c18fcf3a97728e3e4a2870ae08df713a96c09c2ba5022
+    "@vuepress/client": 2.0.0-beta.60
+    "@vuepress/core": 2.0.0-beta.60
+    "@vuepress/utils": 2.0.0-beta.60
+  checksum: 8a3410f33f2bd04a2eb9b59d284c4025dceec87184df544f53e5df4d56b15e85abbafb69d0484049ba9f37576c1e6c578946ab4628bbd7b7debf50074015a2f4
   languageName: node
   linkType: hard
 
@@ -2835,7 +2835,7 @@ __metadata:
   dependencies:
     "@vuepress/plugin-docsearch": ^2.0.0-beta.60
     "@vuepress/plugin-git": ^2.0.0-beta.60
-    "@vuepress/plugin-google-analytics": ^2.0.0-beta.48
+    "@vuepress/plugin-google-analytics": ^2.0.0-beta.60
     "@vuepress/plugin-pwa": ^2.0.0-beta.48
     markdownlint-cli2: ^0.6.0
     vuepress: ^2.0.0-beta.60

--- a/yarn.lock
+++ b/yarn.lock
@@ -2439,17 +2439,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vuepress/plugin-git@npm:^2.0.0-beta.48":
-  version: 2.0.0-beta.50-pre.1
-  resolution: "@vuepress/plugin-git@npm:2.0.0-beta.50-pre.1"
-  dependencies:
-    "@vuepress/core": 2.0.0-beta.50-pre.1
-    "@vuepress/utils": 2.0.0-beta.50-pre.1
-    execa: ^6.1.0
-  checksum: 4021a699b0da24c189d620abb9038d608c3e2cd75e88f1d686ac5417c42ed07afda98da65980662e9d28270fcc1af2db46e5bef5c902d6e95fce3c6d85455a50
-  languageName: node
-  linkType: hard
-
 "@vuepress/plugin-google-analytics@npm:^2.0.0-beta.48":
   version: 2.0.0-beta.50-pre.1
   resolution: "@vuepress/plugin-google-analytics@npm:2.0.0-beta.50-pre.1"
@@ -2845,7 +2834,7 @@ __metadata:
   resolution: "awesome-nuxt@workspace:."
   dependencies:
     "@vuepress/plugin-docsearch": ^2.0.0-beta.60
-    "@vuepress/plugin-git": ^2.0.0-beta.48
+    "@vuepress/plugin-git": ^2.0.0-beta.60
     "@vuepress/plugin-google-analytics": ^2.0.0-beta.48
     "@vuepress/plugin-pwa": ^2.0.0-beta.48
     markdownlint-cli2: ^0.6.0


### PR DESCRIPTION
- build(deps): update vuepress to version 2.0.0-beta.60
- build(deps): update @vuepress/plugin-docsearch to version 2.0.0-beta.60
- build(deps): update @vuepress/plugin-git to version 2.0.0-beta.60
- build(deps): update @vuepress/plugin-google-analytics to version 2.0.0-beta.60
- build(deps): update @vuepress/plugin-pwa to version 2.0.0-beta.60
- build(deps): update browserslist database
- refactor: migration configuration and move it to the new location
