### PR TITLE
Merge branch 'release/2.0.0' into develop

### DIFF
--- a/.changes/v2.0.0.md
+++ b/.changes/v2.0.0.md
@@ -1,9 +1,3 @@
-# Changelog
-
-All notable changes to this project will be documented in this file.
-
-The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org).
-
 ## [v2.0.0](https://github.com/ansidev/sample-gitflow-release-workflows/compare/v1.0.0...v2.0.0) (2023-02-16)
 
 ### Features
@@ -18,16 +12,3 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 - **Dependency:** Migrate from [markdownlint](https://github.com/DavidAnson/markdownlint) to [markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2)
 
 Full Changelog: [v1.0.0...v2.0.0](https://github.com/ansidev/sample-gitflow-release-workflows/compare/v1.0.0...v2.0.0)
-
-## v1.0.0 (2023-02-16)
-
-### Features
-
-- **Package manager**: Yarn v2+.
-- **Static site generator**: VuePress v2.
-- **Site search service**: Algolia.
-- **Site analytic service**: Google Analytics.
-- **Release:** GitHub Actions + Gitflow.
-- **Deployment:** GitHub Pages + Netlify.
-
-Full Changelog: [v1.0.0](https://github.com/ansidev/sample-gitflow-release-workflows/commits/v1.0.0)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,15 +51,19 @@ jobs:
           GA_ID: ${{ secrets.GA_ID }}
         run: pnpm run build
 
-      - name: Ignore deployment
-        if: github.base_ref == 'develop' && success()
-        run: echo "Current branch is ${{ github.base_ref }}. Deployment was ignored"
-
       - name: Deploy to GitHub Pages
-        if: github.base_ref == 'main' && success()
+        if: success() && github.base_ref == 'main' &&
+          github.event.pull_request.action == 'closed' && github.event.pull_request.merged == true
         uses: crazy-max/ghaction-github-pages@v3
         with:
-          target-branch: gh-pages
+          target_branch: gh-pages
           build_dir: content/.vuepress/dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Ignore deployment
+        if: ${{ !success() ||
+          github.base_ref != 'main' ||
+          github.event.pull_request.action != 'closed' ||
+          github.event.pull_request.merged != true }}
+        run: echo "Deployment was ignored"

--- a/.taskfiles/task_release.yaml
+++ b/.taskfiles/task_release.yaml
@@ -57,7 +57,7 @@ tasks:
       VERSION_TAG: ${TAG_PREFIX}{{.CLI_ARGS}}
     cmds:
       - echo "Releasing version {{.VERSION_TAG}}"
-      - task changelog-next -- {{.CLI_ARGS}}
+      - task release:changelog-next -- {{.CLI_ARGS}}
       - changie merge
-      - task commit-release -- {{.CLI_ARGS}}
+      - task release:commit-release -- {{.CLI_ARGS}}
     silent: true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "awesome-nuxt",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "🎉 A curated list of awesome things related to Nuxt.js",
   "private": true,
   "repository": {


### PR DESCRIPTION
This PR merges the branch 'release/2.0.0' back into the branch 'develop'.

This ensures that the updates on the branch 'release/2.0.0', i.e. CHANGELOG and manifest updates, are also present on the branch 'develop'.
