### PR TITLE
Merge branch 'release/2.0.4' into develop

### DIFF
--- a/.changes/v2.0.4.md
+++ b/.changes/v2.0.4.md
@@ -1,0 +1,12 @@
+## [v2.0.4](https://github.com/ansidev/awesome-nuxt/compare/v2.0.3...v2.0.4) (2023-03-30)
+
+### Documentation
+
+- **readme**: update README.md
+
+### Dependencies
+
+- **package-manager**: update minimum pnpm version to v8.1.0
+
+Full Changelog:
+[v2.0.3...v2.0.4](https://github.com/ansidev/awesome-nuxt/compare/v2.0.3...v2.0.4)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org).
 
+## [v2.0.4](https://github.com/ansidev/awesome-nuxt/compare/v2.0.3...v2.0.4) (2023-03-30)
+
+### Documentation
+
+- **readme**: update README.md
+
+### Dependencies
+
+- **package-manager**: update minimum pnpm version to v8.1.0
+
+Full Changelog:
+[v2.0.3...v2.0.4](https://github.com/ansidev/awesome-nuxt/compare/v2.0.3...v2.0.4)
+
 ## [v2.0.3](https://github.com/ansidev/awesome-nuxt/compare/v2.0.2...v2.0.3) (2023-03-27)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "awesome-nuxt",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "🎉 A curated list of awesome things related to Nuxt.js",
   "private": true,
   "repository": {


### PR DESCRIPTION
This PR merges the branch 'release/2.0.4' back into the branch 'develop'.

This ensures that the updates on the branch 'release/2.0.4', i.e. CHANGELOG and manifest updates, are also present on the branch 'develop'.
