### PR TITLE
Merge branch 'release/2.0.6' into develop

### DIFF
--- a/.changes/v2.0.6.md
+++ b/.changes/v2.0.6.md
@@ -1,0 +1,13 @@
+## [v2.0.6](https://github.com/ansidev/awesome-nuxt/compare/v2.0.5...v2.0.6) (2023-06-07)
+
+### Bug Fixes
+
+- **action:** apply reusable GitHub Actions for building and deploying site
+
+- **action:** fix actionlint reports
+
+### Others
+
+- **deps:** update `pnpm` to `v8.6.1`
+
+Full Changelog: [v2.0.5...v2.0.6](https://github.com/ansidev/awesome-nuxt/compare/v2.0.5...v2.0.6)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org).
 
+## [v2.0.6](https://github.com/ansidev/awesome-nuxt/compare/v2.0.5...v2.0.6) (2023-06-07)
+
+### Bug Fixes
+
+- **action:** apply reusable GitHub Actions for building and deploying site
+
+- **action:** fix actionlint reports
+
+### Others
+
+- **deps:** update `pnpm` to `v8.6.1`
+
+Full Changelog: [v2.0.5...v2.0.6](https://github.com/ansidev/awesome-nuxt/compare/v2.0.5...v2.0.6)
+
 ## [v2.0.5](https://github.com/ansidev/awesome-nuxt/compare/v2.0.4...v2.0.5) (2023-05-16)
 
 ### Content

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "awesome-nuxt",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "🎉 A curated list of awesome things related to Nuxt.js",
   "private": true,
   "repository": {


### PR DESCRIPTION
This PR merges the branch 'release/2.0.6' back into the branch 'develop'.

This ensures that the updates on the branch 'release/2.0.6', i.e. CHANGELOG and manifest updates, are also present on the branch 'develop'.
