### PR TITLE
Merge branch 'release/2.1.1' into develop

### DIFF
--- a/.changes/v2.1.1.md
+++ b/.changes/v2.1.1.md
@@ -1,0 +1,17 @@
+## [v2.1.1](https://github.com/ansidev/awesome-nuxt/compare/v2.1.0...v2.1.1) (2024-12-24)
+
+### Dependencies
+
+| Package                             | Version                             |
+| ----------------------------------- | ----------------------------------- |
+| `markdownlint-cli2`                 | `^2.0.0-beta.60` `->` `^2.0.0-rc.2` |
+| `@vuepress/plugin-docsearch`        | `^2.0.0-beta.60` `->` `^2.0.0-rc.0` |
+| `@vuepress/plugin-git`              | `^2.0.0-beta.60` `->` `^2.0.0-rc.0` |
+| `@vuepress/plugin-google-analytics` | `^2.0.0-beta.60` `->` `^2.0.0-rc.0` |
+| `@vuepress/plugin-pwa`              | `^2.0.0-beta.60` `->` `^2.0.0-rc.0` |
+| `markdownlint-cli2`                 | `^0.11.0` `->` `^0.16.0`            |
+| `vue`                               | `^3.3.2` `->` `^3.5.13`             |
+| `vuepress`                          | `^2.0.0-beta.60` `->` `^2.0.0-rc.0` |
+| `pnpm`                              | `^8.11.0` `->` `^9.15.1`            |
+
+Full Changelog: [v2.1.0...v2.1.1](https://github.com/ansidev/awesome-nuxt/compare/v2.1.0...v2.1.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,27 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org).
 
+## [v2.1.1](https://github.com/ansidev/awesome-nuxt/compare/v2.1.0...v2.1.1) (2024-12-24)
+
+### Dependencies
+
+| Package                             | Version                             |
+| ----------------------------------- | ----------------------------------- |
+| `markdownlint-cli2`                 | `^2.0.0-beta.60` `->` `^2.0.0-rc.2` |
+| `@vuepress/plugin-docsearch`        | `^2.0.0-beta.60` `->` `^2.0.0-rc.0` |
+| `@vuepress/plugin-git`              | `^2.0.0-beta.60` `->` `^2.0.0-rc.0` |
+| `@vuepress/plugin-google-analytics` | `^2.0.0-beta.60` `->` `^2.0.0-rc.0` |
+| `@vuepress/plugin-pwa`              | `^2.0.0-beta.60` `->` `^2.0.0-rc.0` |
+| `markdownlint-cli2`                 | `^0.11.0` `->` `^0.16.0`            |
+| `vue`                               | `^3.3.2` `->` `^3.5.13`             |
+| `vuepress`                          | `^2.0.0-beta.60` `->` `^2.0.0-rc.0` |
+| `pnpm`                              | `^8.11.0` `->` `^9.15.1`            |
+
+Full Changelog: [v2.1.0...v2.1.1](https://github.com/ansidev/awesome-nuxt/compare/v2.1.0...v2.1.1)
+
 ## [v2.1.0](https://github.com/ansidev/awesome-nuxt/compare/v2.0.6...v2.1.0) (2023-12-03)
 
 ### Bug Fixes
-
-- update renovate config
 
 - **github-workflow:** update Node version
 
@@ -16,7 +32,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ### Features
 
-- **config:** update renovate.json
+- **renovate:** update renovate config
 
 - **github-workflow:** automate deploying site to Netlify
 

--- a/content/resources/showcase.md
+++ b/content/resources/showcase.md
@@ -83,3 +83,4 @@
 - [Never Have I Ever Online - Questions & Game](https://neverhaveiever.online/) - Never Have I Ever Online Questions & Game, play with friends online or offline.
 - [viblo.asia](https://viblo.asia) - Free service for technical knowledge sharing
 - [Project Powder](https://theprojectpowder.com/) - A snow resort discovery PWA built using NuxtJS and Buefy.
+- [Free Code Tools](https://freecodetools.org/) - Collection of free SEO and code tools.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "awesome-nuxt",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "🎉 A curated list of awesome things related to Nuxt.js",
   "private": true,
   "repository": {


### PR DESCRIPTION
This PR merges the branch 'release/2.1.1' back into the branch 'develop'.

This ensures that the updates on the branch 'release/2.1.1', i.e. CHANGELOG and manifest updates, are also present on the branch 'develop'.
