### PR TITLE
chore(deps): update vuepress monorepo

### DIFF
--- a/docs/superpowers/plans/2026-03-15-update-markdownlint-cli2.md
+++ b/docs/superpowers/plans/2026-03-15-update-markdownlint-cli2.md
@@ -1,0 +1,410 @@
+# Update markdownlint-cli2 Dependency Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Update the `markdownlint-cli2` package range pin from `^0.18.0` to `^0.21.0` in a dedicated git worktree, fix any new lint violations introduced by the version bump, and open a PR targeting `develop`.
+
+**Architecture:** Create an isolated git worktree from `develop`, bump the version range in `package.json`, reinstall dependencies, run lint to detect new violations, fix any violations in a separate commit from the version bump, verify build, and open a PR.
+
+**Tech Stack:** git worktrees, pnpm, markdownlint-cli2, VuePress 2
+
+---
+
+## Task 1: Create the git worktree
+
+All worktree creation commands run from the **main repo root**: `/Users/ansidev/projects/personal/awesome-nuxt`.
+
+- [ ] Ensure you are on the `develop` branch and it is up to date:
+
+  ```sh
+  cd /Users/ansidev/projects/personal/awesome-nuxt
+  git checkout develop
+  git pull origin develop
+  ```
+
+  Expected output: `Already up to date.` (or a list of pulled commits if behind).
+
+- [ ] Ensure the worktree base directory exists:
+
+  ```sh
+  mkdir -p /Users/ansidev/git-worktrees/awesome-nuxt
+  ```
+
+- [ ] Create the worktree and new branch in one step:
+
+  ```sh
+  git worktree add /Users/ansidev/git-worktrees/awesome-nuxt/update-markdownlint -b chore/update-markdownlint-cli2 develop
+  ```
+
+  Expected output:
+  ```
+  Preparing worktree (new branch 'chore/update-markdownlint-cli2')
+  HEAD is now at <commit-hash> <last-commit-message>
+  ```
+
+- [ ] Confirm the worktree was created and the branch is correct:
+
+  ```sh
+  git worktree list
+  ```
+
+  Expected output includes a line like:
+  ```
+  /Users/ansidev/git-worktrees/awesome-nuxt/update-markdownlint  <hash>  [chore/update-markdownlint-cli2]
+  ```
+
+> **From this point forward, ALL commands run from inside the worktree directory:**
+> `/Users/ansidev/git-worktrees/awesome-nuxt/update-markdownlint`
+
+---
+
+## Task 2: Update `package.json`
+
+- [ ] Open `/Users/ansidev/git-worktrees/awesome-nuxt/update-markdownlint/package.json` and update the `markdownlint-cli2` version range. The exact change is:
+
+  **Before:**
+  ```json
+  "markdownlint-cli2": "^0.18.0",
+  ```
+
+  **After:**
+  ```json
+  "markdownlint-cli2": "^0.21.0",
+  ```
+
+  The relevant section in `devDependencies` (around line 41) should look like:
+  ```json
+  "devDependencies": {
+    ...
+    "markdownlint-cli2": "^0.21.0",
+    ...
+  }
+  ```
+
+- [ ] Verify the change with a quick inspection:
+
+  ```sh
+  grep markdownlint-cli2 /Users/ansidev/git-worktrees/awesome-nuxt/update-markdownlint/package.json
+  ```
+
+  Expected output:
+  ```
+      "markdownlint-cli2": "^0.21.0",
+  ```
+
+---
+
+## Task 3: Reinstall dependencies
+
+- [ ] Run `pnpm install` to update the lockfile and install the new version:
+
+  ```sh
+  cd /Users/ansidev/git-worktrees/awesome-nuxt/update-markdownlint
+  pnpm install
+  ```
+
+  Expected output: pnpm resolves and installs packages. The lockfile (`pnpm-lock.yaml`) will be updated. Look for a line indicating `markdownlint-cli2` is updated, e.g.:
+
+  ```
+  Packages: +X -Y
+  Progress: resolved NNN, reused NNN, downloaded N, added N, removed N, done
+  ```
+
+- [ ] Confirm the lockfile now resolves `markdownlint-cli2` to `0.21.0`:
+
+  ```sh
+  grep -A2 "markdownlint-cli2" /Users/ansidev/git-worktrees/awesome-nuxt/update-markdownlint/pnpm-lock.yaml | head -10
+  ```
+
+  Expected output includes:
+  ```
+  markdownlint-cli2@0.21.0:
+  ```
+
+---
+
+## Task 4: Run lint and fix violations (if any)
+
+### 4a. Run `pnpm lint` and check for errors
+
+- [ ] Run the linter:
+
+  ```sh
+  cd /Users/ansidev/git-worktrees/awesome-nuxt/update-markdownlint
+  pnpm lint
+  ```
+
+  The lint command expands to:
+  ```sh
+  markdownlint-cli2 ./content/**/*.md
+  ```
+
+  This checks all 16 markdown files: `content/index.md` plus the 15 files under `content/resources/` (`blogs.md`, `books.md`, `community-examples.md`, `community.md`, `docker.md`, `mention-of-nuxt.md`, `modules.md`, `official-examples.md`, `official-resources.md`, `open-source-projects-using-nuxt.md`, `projects-using-nuxt.md`, `showcase.md`, `starter-template.md`, `tools.md`, `tutorials.md`).
+
+  **If output ends with `0 errors` and exit code is 0:** skip to Task 5 (build).
+
+  **If errors are reported:** continue with steps 4b–4d below.
+
+### 4b. Diagnose which rules changed between 0.18.x and 0.21.0
+
+- [ ] Consult the changelogs to understand which new rules or rule-behavior changes were introduced:
+
+  - markdownlint-cli2 changelog: https://github.com/DavidAnson/markdownlint-cli2/blob/main/CHANGELOG.md
+    - Look at entries for versions `0.19.0`, `0.20.0`, and `0.21.0`.
+  - markdownlint (the underlying rule engine) changelog: https://github.com/DavidAnson/markdownlint/blob/main/CHANGELOG.md
+    - Cross-reference the `markdownlint` version bundled with each `markdownlint-cli2` release to identify any new default rules.
+
+  Common sources of new violations after a minor bump:
+  - New rules enabled by `default: true` that did not exist before.
+  - Existing rules with stricter defaults (e.g., tighter line-length handling, new list-indent rules).
+
+- [ ] Review the lint output to identify which rule IDs are triggering (e.g., `MD001`, `MD047`, `MD055`). Each error line follows the format:
+  ```
+  content/resources/modules.md:42:3 MD007/ul-indent Unordered list indentation [Expected: 2; Actual: 4]
+  ```
+
+### 4c. Fix the violations
+
+Decide on a fix strategy for each rule:
+
+**Option A — Fix the content files** (preferred when the markdown is genuinely malformed):
+
+  - Edit the offending lines in the relevant files under `content/` to satisfy the rule.
+  - Re-run `pnpm lint` after each batch of fixes to track progress.
+
+**Option B — Relax the rule in `.markdownlint-cli2.cjs`** (appropriate when the rule change is overly strict for this project's content style):
+
+  The config file is at:
+  `/Users/ansidev/git-worktrees/awesome-nuxt/update-markdownlint/.markdownlint-cli2.cjs`
+
+  Its current contents:
+  ```js
+  module.exports = {
+    ignores: [
+      '**/.git',
+      '**/.idea',
+      '**/.vscode',
+      '**/node_modules',
+    ],
+    config: {
+      default: true,
+      MD013: {
+        line_length: 1000,
+      },
+    },
+  }
+  ```
+
+  To disable a new rule (e.g., `MD055`), add it to the `config` block:
+  ```js
+  config: {
+    default: true,
+    MD013: {
+      line_length: 1000,
+    },
+    MD055: false,
+  },
+  ```
+
+  To configure a rule instead of disabling it, pass an options object instead of `false`.
+
+### 4d. Confirm lint is clean after fixes
+
+- [ ] Re-run `pnpm lint` and confirm zero errors:
+
+  ```sh
+  cd /Users/ansidev/git-worktrees/awesome-nuxt/update-markdownlint
+  pnpm lint
+  ```
+
+  Expected output:
+  ```
+  markdownlint-cli2 v0.21.0 (markdownlint vX.Y.Z)
+  Finding: ./content/**/*.md
+  Linting: 16 file(s)
+  Summary: 0 error(s)
+  ```
+
+- [ ] Stage and commit lint fixes in a **separate commit** (this commit must come BEFORE the version bump commit):
+
+  ```sh
+  cd /Users/ansidev/git-worktrees/awesome-nuxt/update-markdownlint
+  git add content/ .markdownlint-cli2.cjs
+  git commit -m "fix: fix markdownlint violations after updating to markdownlint-cli2 v0.21.0"
+  ```
+
+  Only include files that were actually changed. Do not stage `package.json` or `pnpm-lock.yaml` in this commit.
+
+---
+
+## Task 5: Verify the build
+
+- [ ] Run the VuePress build to confirm the site builds successfully with the updated dependencies:
+
+  ```sh
+  cd /Users/ansidev/git-worktrees/awesome-nuxt/update-markdownlint
+  pnpm build
+  ```
+
+  The build command expands to:
+  ```sh
+  vuepress build content
+  ```
+
+  Expected: the command exits with code 0. The final lines of output should resemble:
+  ```
+  ✔ Compiling with vite - done
+  ✔ Rendering pages - done
+  ```
+
+  If the build fails, investigate the error output. Build failures at this stage are typically unrelated to the markdownlint bump (they may be pre-existing issues), but confirm by checking `git stash` behaviour if needed.
+
+---
+
+## Task 6: Commit the version bump
+
+- [ ] Stage the `package.json` and `pnpm-lock.yaml` changes:
+
+  ```sh
+  cd /Users/ansidev/git-worktrees/awesome-nuxt/update-markdownlint
+  git add package.json pnpm-lock.yaml
+  ```
+
+- [ ] Commit with the conventional commit message:
+
+  ```sh
+  git commit -m "chore(deps): update dependency markdownlint-cli2 to v0.21.0"
+  ```
+
+- [ ] Verify the commit log shows the correct order of commits (lint fixes first, version bump second):
+
+  ```sh
+  git log --oneline -5
+  ```
+
+  Expected (if lint fixes were needed):
+  ```
+  <hash> chore(deps): update dependency markdownlint-cli2 to v0.21.0
+  <hash> fix: fix markdownlint violations after updating to markdownlint-cli2 v0.21.0
+  <hash> <previous develop commit>
+  ...
+  ```
+
+  Expected (if no lint fixes were needed):
+  ```
+  <hash> chore(deps): update dependency markdownlint-cli2 to v0.21.0
+  <hash> <previous develop commit>
+  ...
+  ```
+
+---
+
+## Task 7: Push and open a pull request
+
+- [ ] Push the branch to the remote:
+
+  ```sh
+  cd /Users/ansidev/git-worktrees/awesome-nuxt/update-markdownlint
+  git push -u origin chore/update-markdownlint-cli2
+  ```
+
+  Expected output:
+  ```
+  To github.com:ansidev/awesome-nuxt.git
+   * [new branch]      chore/update-markdownlint-cli2 -> chore/update-markdownlint-cli2
+  Branch 'chore/update-markdownlint-cli2' set up to track remote branch 'chore/update-markdownlint-cli2' from 'origin'.
+  ```
+
+- [ ] Open a PR targeting `develop`.
+
+  **If no lint fixes were needed**, use this command:
+
+  ```sh
+  gh pr create \
+    --base develop \
+    --title "chore(deps): update dependency markdownlint-cli2 to v0.21.0" \
+    --body "## Summary
+
+  - Bumps \`markdownlint-cli2\` range pin from \`^0.18.0\` to \`^0.21.0\`
+  - Lockfile updated: resolves from 0.18.1 → 0.21.0
+  - No new lint violations introduced by the version bump
+
+  ## Test plan
+
+  - [ ] \`pnpm lint\` exits with 0 errors
+  - [ ] \`pnpm build\` completes successfully"
+  ```
+
+  **If lint fixes were needed**, include a note about which rules changed. Adapt the body template:
+
+  ```sh
+  gh pr create \
+    --base develop \
+    --title "chore(deps): update dependency markdownlint-cli2 to v0.21.0" \
+    --body "## Summary
+
+  - Bumps \`markdownlint-cli2\` range pin from \`^0.18.0\` to \`^0.21.0\`
+  - Lockfile updated: resolves from 0.18.1 → 0.21.0
+  - Fixed lint violations introduced by new/changed rules: <list rule IDs here, e.g. MD055, MD058>
+  - See the fix commit for details on which files and rules were affected
+
+  ## Rule changes (0.18.x → 0.21.0)
+
+  <Summarise the relevant CHANGELOG entries here, e.g.:>
+  - **MD055** (table-pipe-style): new rule added in markdownlint vX.Y, requires consistent pipe style in tables
+  - Content files updated / rule disabled in \`.markdownlint-cli2.cjs\` as appropriate
+
+  ## Test plan
+
+  - [ ] \`pnpm lint\` exits with 0 errors
+  - [ ] \`pnpm build\` completes successfully"
+  ```
+
+- [ ] Note the PR URL printed by `gh pr create` and confirm the PR is visible on GitHub with the correct base branch (`develop`).
+
+---
+
+## Task 8: Teardown after the PR is merged
+
+Run these commands after the PR has been merged into `develop`.
+
+- [ ] Switch back to the main repo and fetch the updated `develop` branch:
+
+  ```sh
+  cd /Users/ansidev/projects/personal/awesome-nuxt
+  git checkout develop
+  git pull origin develop
+  ```
+
+- [ ] Remove the worktree:
+
+  ```sh
+  git worktree remove /Users/ansidev/git-worktrees/awesome-nuxt/update-markdownlint
+  ```
+
+  Expected output: no output (silent success). The directory `/Users/ansidev/git-worktrees/awesome-nuxt/update-markdownlint` will no longer exist.
+
+- [ ] Delete the local branch:
+
+  ```sh
+  git branch -d chore/update-markdownlint-cli2
+  ```
+
+  Expected output:
+  ```
+  Deleted branch chore/update-markdownlint-cli2 (was <hash>).
+  ```
+
+- [ ] Optionally delete the remote tracking branch:
+
+  ```sh
+  git push origin --delete chore/update-markdownlint-cli2
+  ```
+
+- [ ] Verify the worktree list is clean:
+
+  ```sh
+  git worktree list
+  ```
+
+  Expected output: only the main worktree entry remains, with no reference to `update-markdownlint`.

--- a/docs/superpowers/plans/2026-03-15-update-sass-embedded.md
+++ b/docs/superpowers/plans/2026-03-15-update-sass-embedded.md
@@ -1,0 +1,342 @@
+# Update sass-embedded Dependency Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Update the `sass-embedded` package range pin from `^1.83.0` to `^1.98.0` in a dedicated git worktree and open a PR targeting `develop`.
+
+**Architecture:** Create an isolated git worktree from `develop`, bump the version range in `package.json`, reinstall dependencies, verify with lint and build, commit, and open a PR.
+
+**Tech Stack:** git worktrees, pnpm, VuePress 2, Sass
+
+---
+
+## Task 1: Create the Git Worktree
+
+A git worktree lets you check out a second branch of the same repository into a separate directory, without disturbing your main working copy. All commands in this task run from the **main repo root**.
+
+- [ ] Ensure you are on the `develop` branch in the main repo and it is up to date:
+
+  ```sh
+  # Run from: /Users/ansidev/projects/personal/awesome-nuxt
+  git checkout develop
+  git pull origin develop
+  ```
+
+  Expected output: `Already on 'develop'` (or a fast-forward merge summary) followed by `Already up to date.`
+
+- [ ] Create the worktree directory parent if it does not already exist:
+
+  ```sh
+  # Run from: /Users/ansidev/projects/personal/awesome-nuxt
+  mkdir -p /Users/ansidev/git-worktrees/awesome-nuxt
+  ```
+
+  Expected output: (none — the command succeeds silently)
+
+- [ ] Add the worktree, creating a new branch `chore/update-sass-embedded` based on `develop`:
+
+  ```sh
+  # Run from: /Users/ansidev/projects/personal/awesome-nuxt
+  git worktree add -b chore/update-sass-embedded \
+    /Users/ansidev/git-worktrees/awesome-nuxt/update-sass \
+    develop
+  ```
+
+  Expected output:
+
+  ```
+  Preparing worktree (new branch 'chore/update-sass-embedded')
+  HEAD is now at <commit-hash> <most-recent-commit-message>
+  ```
+
+- [ ] Verify the worktree was created correctly:
+
+  ```sh
+  # Run from: /Users/ansidev/projects/personal/awesome-nuxt
+  git worktree list
+  ```
+
+  Expected output should include two entries — the main repo and the new worktree — for example:
+
+  ```
+  /Users/ansidev/projects/personal/awesome-nuxt           <hash> [develop]
+  /Users/ansidev/git-worktrees/awesome-nuxt/update-sass   <hash> [chore/update-sass-embedded]
+  ```
+
+---
+
+## Task 2: Update `package.json`
+
+All remaining commands (Tasks 2–8) run from inside the **worktree directory** unless stated otherwise.
+
+- [ ] Change to the worktree directory:
+
+  ```sh
+  cd /Users/ansidev/git-worktrees/awesome-nuxt/update-sass
+  ```
+
+- [ ] Open `package.json` and update the `sass-embedded` version range. The file is at:
+
+  `/Users/ansidev/git-worktrees/awesome-nuxt/update-sass/package.json`
+
+  Find the line (line 42):
+
+  ```json
+  "sass-embedded": "^1.83.0",
+  ```
+
+  Change it to:
+
+  ```json
+  "sass-embedded": "^1.98.0",
+  ```
+
+  The surrounding `devDependencies` block should look like this after the edit:
+
+  ```json
+  "devDependencies": {
+    "@vuepress/bundler-vite": "^2.0.0-rc.19",
+    "@vuepress/client": "^2.0.0-rc.19",
+    "@vuepress/plugin-docsearch": "^2.0.0-rc.67",
+    "@vuepress/plugin-git": "^2.0.0-rc.66",
+    "@vuepress/plugin-google-analytics": "^2.0.0-rc.66",
+    "@vuepress/plugin-pwa": "^2.0.0-rc.66",
+    "@vuepress/theme-default": "^2.0.0-rc.66",
+    "markdownlint-cli2": "^0.18.0",
+    "sass-embedded": "^1.98.0",
+    "vue": "^3.5.13",
+    "vuepress": "^2.0.0-rc.19"
+  },
+  ```
+
+- [ ] Confirm the change is correct before proceeding:
+
+  ```sh
+  # Run from: /Users/ansidev/git-worktrees/awesome-nuxt/update-sass
+  grep "sass-embedded" package.json
+  ```
+
+  Expected output:
+
+  ```
+      "sass-embedded": "^1.98.0",
+  ```
+
+---
+
+## Task 3: Run `pnpm install`
+
+Installing dependencies with the updated range causes pnpm to resolve `sass-embedded` to its latest compatible version (1.98.0) and update the lockfile accordingly.
+
+- [ ] Run the install:
+
+  ```sh
+  # Run from: /Users/ansidev/git-worktrees/awesome-nuxt/update-sass
+  pnpm install
+  ```
+
+  Expected output ends with something like:
+
+  ```
+  Packages: +1 -1
+  Progress: resolved <N>, reused <N>, downloaded 1, added 1, done
+  ```
+
+- [ ] Confirm the lockfile now resolves `sass-embedded` to `1.98.0`:
+
+  ```sh
+  # Run from: /Users/ansidev/git-worktrees/awesome-nuxt/update-sass
+  grep "sass-embedded" pnpm-lock.yaml | head -5
+  ```
+
+  Expected output should contain a line like:
+
+  ```
+  sass-embedded@1.98.0:
+  ```
+
+  (The exact surrounding context will vary, but `1.97.3` should no longer appear for the primary resolved version.)
+
+---
+
+## Task 4: Run `pnpm lint`
+
+The lint command runs `markdownlint-cli2` against all Markdown files in `content/`. The baseline is 0 errors; the dependency bump should not affect Markdown content.
+
+- [ ] Run the linter:
+
+  ```sh
+  # Run from: /Users/ansidev/git-worktrees/awesome-nuxt/update-sass
+  pnpm lint
+  ```
+
+  Expected output:
+
+  ```
+  markdownlint-cli2 v<version> (markdownlint v<version>)
+  Finding: ./content/**/*.md
+  Linting: <N> file(s)
+  Summary: 0 error(s)
+  ```
+
+  If any errors appear, they are pre-existing issues unrelated to this change. Do not modify Markdown files as part of this task — stop and investigate before continuing.
+
+---
+
+## Task 5: Run `pnpm build`
+
+The build command runs `vuepress build content`, which compiles the entire static site. A successful build confirms that `sass-embedded` at `1.98.0` is fully compatible with the project's Sass usage.
+
+- [ ] Run the build:
+
+  ```sh
+  # Run from: /Users/ansidev/git-worktrees/awesome-nuxt/update-sass
+  pnpm build
+  ```
+
+  Expected output ends with something like:
+
+  ```
+  ✓ Initializing and preparing data - done in <N>s
+  ✓ Compiling with vite
+  ✓ Rendering pages - done in <N>s
+  ```
+
+  The command must exit with code 0. If the build fails with Sass-related errors, check the [sass-embedded 1.98.0 release notes](https://github.com/sass/dart-sass/releases) for any breaking changes and address them before continuing.
+
+---
+
+## Task 6: Commit the Changes
+
+- [ ] Stage the two modified files (`package.json` and `pnpm-lock.yaml`):
+
+  ```sh
+  # Run from: /Users/ansidev/git-worktrees/awesome-nuxt/update-sass
+  git add package.json pnpm-lock.yaml
+  ```
+
+- [ ] Verify only those two files are staged (no unintended changes):
+
+  ```sh
+  # Run from: /Users/ansidev/git-worktrees/awesome-nuxt/update-sass
+  git status
+  ```
+
+  Expected output:
+
+  ```
+  On branch chore/update-sass-embedded
+  Changes to be committed:
+    (use "git restore --staged <file>..." to unstage)
+          modified:   package.json
+          modified:   pnpm-lock.yaml
+  ```
+
+- [ ] Create the commit:
+
+  ```sh
+  # Run from: /Users/ansidev/git-worktrees/awesome-nuxt/update-sass
+  git commit -m "chore(deps): update dependency sass-embedded to v1.98.0"
+  ```
+
+  Expected output:
+
+  ```
+  [chore/update-sass-embedded <hash>] chore(deps): update dependency sass-embedded to v1.98.0
+   2 files changed, <N> insertions(+), <N> deletions(-)
+  ```
+
+---
+
+## Task 7: Push the Branch and Open a Pull Request
+
+- [ ] Push the branch to the remote:
+
+  ```sh
+  # Run from: /Users/ansidev/git-worktrees/awesome-nuxt/update-sass
+  git push -u origin chore/update-sass-embedded
+  ```
+
+  Expected output:
+
+  ```
+  Enumerating objects: <N>, done.
+  ...
+  To https://github.com/ansidev/awesome-nuxt.git
+   * [new branch]      chore/update-sass-embedded -> chore/update-sass-embedded
+  Branch 'chore/update-sass-embedded' set up to track remote branch 'chore/update-sass-embedded' from 'origin'.
+  ```
+
+- [ ] Open the pull request targeting `develop`:
+
+  ```sh
+  # Run from: /Users/ansidev/git-worktrees/awesome-nuxt/update-sass
+  gh pr create \
+    --title "chore(deps): update dependency sass-embedded to v1.98.0" \
+    --base develop \
+    --body "## Summary
+
+  Bumps the \`sass-embedded\` dev dependency range pin from \`^1.83.0\` to \`^1.98.0\`.
+
+  The lockfile now resolves \`sass-embedded\` to \`1.98.0\` (previously \`1.97.3\`).
+
+  ## Verification
+
+  - \`pnpm lint\`: 0 errors (unchanged baseline)
+  - \`pnpm build\`: completes successfully
+
+  ## Release notes
+
+  See the [sass-embedded / dart-sass releases](https://github.com/sass/dart-sass/releases) for the full changelog between 1.83.0 and 1.98.0."
+  ```
+
+  Expected output:
+
+  ```
+  https://github.com/ansidev/awesome-nuxt/pull/<number>
+  ```
+
+  Copy the PR URL for review.
+
+---
+
+## Task 8: Teardown After the PR is Merged
+
+Once the PR has been reviewed, approved, and merged into `develop`, clean up the local worktree and branch.
+
+- [ ] Remove the worktree (run from the **main repo root**, not the worktree itself):
+
+  ```sh
+  # Run from: /Users/ansidev/projects/personal/awesome-nuxt
+  git worktree remove /Users/ansidev/git-worktrees/awesome-nuxt/update-sass
+  ```
+
+  Expected output: (none — the command succeeds silently)
+
+- [ ] Delete the local branch:
+
+  ```sh
+  # Run from: /Users/ansidev/projects/personal/awesome-nuxt
+  git branch -d chore/update-sass-embedded
+  ```
+
+  Expected output:
+
+  ```
+  Deleted branch chore/update-sass-embedded (was <hash>).
+  ```
+
+- [ ] Optionally delete the remote tracking branch if it was not deleted automatically by GitHub:
+
+  ```sh
+  # Run from: /Users/ansidev/projects/personal/awesome-nuxt
+  git remote prune origin
+  ```
+
+- [ ] Pull the merged changes into your local `develop`:
+
+  ```sh
+  # Run from: /Users/ansidev/projects/personal/awesome-nuxt
+  git checkout develop
+  git pull origin develop
+  ```

--- a/docs/superpowers/plans/2026-03-15-update-vue.md
+++ b/docs/superpowers/plans/2026-03-15-update-vue.md
@@ -1,0 +1,322 @@
+# Update vue Dependency Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Update the `vue` package range pin from `^3.5.13` to `^3.5.30` in a dedicated git worktree and open a PR targeting `develop`.
+
+**Architecture:** Create an isolated git worktree from `develop`, bump the version range in `package.json`, reinstall dependencies, verify with lint and build, commit, and open a PR.
+
+**Tech Stack:** git worktrees, pnpm, VuePress 2
+
+---
+
+## Background
+
+This plan updates the `vue` devDependency in the `awesome-nuxt` project. The project is a VuePress 2 static site managed with pnpm. The lockfile already resolves `vue` to `3.5.29`; after this bump the lockfile will resolve to `3.5.30`.
+
+All work happens inside a dedicated git worktree to keep the main checkout clean and allow parallel work on other branches. The worktree is a separate directory on disk that shares the same underlying git object store as the main repository.
+
+---
+
+## Task 1: Create the Git Worktree
+
+A git worktree is an additional working tree linked to the same repository. This lets you check out a different branch in a separate directory without disturbing the main checkout.
+
+- [ ] From the main repository directory, create the worktree and branch in one command:
+
+  ```sh
+  cd /Users/ansidev/projects/personal/awesome-nuxt
+  git worktree add -b chore/update-vue /Users/ansidev/git-worktrees/awesome-nuxt/update-vue develop
+  ```
+
+  Expected output:
+
+  ```
+  Preparing worktree (new branch 'chore/update-vue')
+  HEAD is now at <commit-hash> <last commit message on develop>
+  ```
+
+- [ ] Verify the worktree was created and is on the correct branch:
+
+  ```sh
+  git worktree list
+  ```
+
+  Expected output includes a line like:
+
+  ```
+  /Users/ansidev/git-worktrees/awesome-nuxt/update-vue  <commit-hash>  [chore/update-vue]
+  ```
+
+- [ ] Switch into the worktree directory. All remaining commands in Tasks 2–7 are run from this directory:
+
+  ```sh
+  cd /Users/ansidev/git-worktrees/awesome-nuxt/update-vue
+  ```
+
+---
+
+## Task 2: Update `package.json`
+
+Edit `package.json` to raise the `vue` version range pin from `^3.5.13` to `^3.5.30`.
+
+- [ ] Open `/Users/ansidev/git-worktrees/awesome-nuxt/update-vue/package.json` in your editor (or use a tool) and change line 43:
+
+  Before:
+
+  ```json
+  "vue": "^3.5.13",
+  ```
+
+  After:
+
+  ```json
+  "vue": "^3.5.30",
+  ```
+
+  No other lines should change.
+
+- [ ] Confirm the change is correct:
+
+  ```sh
+  grep '"vue"' /Users/ansidev/git-worktrees/awesome-nuxt/update-vue/package.json
+  ```
+
+  Expected output:
+
+  ```
+      "vue": "^3.5.30",
+  ```
+
+---
+
+## Task 3: Install Dependencies
+
+Run `pnpm install` to update the lockfile so it resolves `vue` to `3.5.30`.
+
+- [ ] Run the install from inside the worktree directory:
+
+  ```sh
+  cd /Users/ansidev/git-worktrees/awesome-nuxt/update-vue
+  pnpm install
+  ```
+
+  Expected output ends with something like:
+
+  ```
+  Packages: +1 -1
+  Progress: resolved N, reused N, downloaded 1, added 1, done
+  ```
+
+- [ ] Confirm the lockfile now resolves vue to `3.5.30`:
+
+  ```sh
+  grep -A2 "^vue@" /Users/ansidev/git-worktrees/awesome-nuxt/update-vue/pnpm-lock.yaml | head -6
+  ```
+
+  Expected: the resolved version shown is `3.5.30`, not `3.5.29`.
+
+---
+
+## Task 4: Lint Verification
+
+Run the project's lint command to ensure no markdown errors have been introduced (baseline is 0 errors).
+
+- [ ] Run lint from inside the worktree directory:
+
+  ```sh
+  cd /Users/ansidev/git-worktrees/awesome-nuxt/update-vue
+  pnpm lint
+  ```
+
+  This runs: `markdownlint-cli2 ./content/**/*.md`
+
+  Expected output: the command exits with code 0 and reports no errors. Example:
+
+  ```
+  markdownlint-cli2 v0.x.x (markdownlint vX.X.X)
+  Finding: ./content/**/*.md
+  Linting: N file(s)
+  Summary: 0 error(s)
+  ```
+
+- [ ] If any errors are reported, investigate and fix them before continuing. A dependency version bump should not affect markdown content, so errors here likely indicate a pre-existing issue or an environmental problem.
+
+---
+
+## Task 5: Build Verification
+
+Run the VuePress build to confirm the site compiles without errors after the dependency update.
+
+- [ ] Run the build from inside the worktree directory:
+
+  ```sh
+  cd /Users/ansidev/git-worktrees/awesome-nuxt/update-vue
+  pnpm build
+  ```
+
+  This runs: `vuepress build content`
+
+  Expected: the build completes successfully. The final lines of output look similar to:
+
+  ```
+  ✓ Compiling with vite - done
+  ✓ Rendering pages - done
+  ```
+
+  The command exits with code 0.
+
+- [ ] If the build fails, check the error output carefully. A failure here after a minor vue patch bump is unexpected — verify that `pnpm install` completed cleanly in Task 3 and that there are no conflicting peer dependency issues.
+
+---
+
+## Task 6: Commit the Changes
+
+Commit the two changed files (`package.json` and `pnpm-lock.yaml`) with the conventional commit message matching the project style.
+
+- [ ] Stage the two changed files explicitly (do not use `git add .` to avoid accidentally staging unintended files):
+
+  ```sh
+  cd /Users/ansidev/git-worktrees/awesome-nuxt/update-vue
+  git add package.json pnpm-lock.yaml
+  ```
+
+- [ ] Verify only the expected files are staged:
+
+  ```sh
+  git status
+  ```
+
+  Expected output:
+
+  ```
+  On branch chore/update-vue
+  Changes to be committed:
+    (use "git restore --staged <file>..." to unstage)
+          modified:   package.json
+          modified:   pnpm-lock.yaml
+  ```
+
+- [ ] Create the commit:
+
+  ```sh
+  git commit -m "chore(deps): update dependency vue to v3.5.30"
+  ```
+
+  Expected output:
+
+  ```
+  [chore/update-vue <commit-hash>] chore(deps): update dependency vue to v3.5.30
+   2 files changed, N insertions(+), N deletions(-)
+  ```
+
+---
+
+## Task 7: Push Branch and Open Pull Request
+
+Push the branch to the remote and open a PR targeting `develop` using the GitHub CLI (`gh`).
+
+- [ ] Push the branch to the remote:
+
+  ```sh
+  cd /Users/ansidev/git-worktrees/awesome-nuxt/update-vue
+  git push -u origin chore/update-vue
+  ```
+
+  Expected output:
+
+  ```
+  To https://github.com/ansidev/awesome-nuxt.git
+   * [new branch]      chore/update-vue -> chore/update-vue
+  Branch 'chore/update-vue' set up to track remote branch 'chore/update-vue' from 'origin'.
+  ```
+
+- [ ] Open the pull request using `gh pr create`:
+
+  ```sh
+  gh pr create \
+    --title "chore(deps): update dependency vue to v3.5.30" \
+    --base develop \
+    --body "$(cat <<'EOF'
+  ## Summary
+
+  Bumps the `vue` devDependency range pin from `^3.5.13` to `^3.5.30`.
+
+  | Package | From    | To      |
+  |---------|---------|---------|
+  | vue     | ^3.5.13 | ^3.5.30 |
+
+  The lockfile now resolves `vue` to `3.5.30` (previously `3.5.29`).
+
+  ## Verification
+
+  - `pnpm lint` — 0 errors (matches baseline)
+  - `pnpm build` — VuePress build completes successfully
+  EOF
+  )"
+  ```
+
+  Expected output: a URL to the newly created pull request, e.g.:
+
+  ```
+  https://github.com/ansidev/awesome-nuxt/pull/NNN
+  ```
+
+- [ ] Open the PR URL in a browser and confirm:
+  - Title is `chore(deps): update dependency vue to v3.5.30`
+  - Base branch is `develop`
+  - The diff shows only `package.json` and `pnpm-lock.yaml`
+  - CI checks pass (if configured)
+
+---
+
+## Task 8: Teardown After Merge
+
+Once the PR is merged into `develop`, clean up the local worktree and branch.
+
+- [ ] Confirm the PR has been merged (check GitHub UI or run):
+
+  ```sh
+  gh pr view --web
+  ```
+
+- [ ] Remove the worktree from the filesystem. Run this from the **main repo directory** (not from inside the worktree being removed):
+
+  ```sh
+  cd /Users/ansidev/projects/personal/awesome-nuxt
+  git worktree remove /Users/ansidev/git-worktrees/awesome-nuxt/update-vue
+  ```
+
+  Expected output: no output (silent success). The directory `/Users/ansidev/git-worktrees/awesome-nuxt/update-vue` is deleted.
+
+- [ ] Delete the local tracking branch:
+
+  ```sh
+  git branch -d chore/update-vue
+  ```
+
+  Expected output:
+
+  ```
+  Deleted branch chore/update-vue (was <commit-hash>).
+  ```
+
+  If git refuses with "not fully merged", double-check the PR was actually merged. If it was merged via squash or rebase, use `-D` instead of `-d` and confirm intentionally:
+
+  ```sh
+  git branch -D chore/update-vue
+  ```
+
+- [ ] Optionally, prune the remote tracking reference:
+
+  ```sh
+  git fetch --prune
+  ```
+
+- [ ] Verify the worktree list no longer shows the removed entry:
+
+  ```sh
+  git worktree list
+  ```
+
+  Expected output: only the main worktree is listed.

--- a/docs/superpowers/plans/2026-03-15-update-vuepress.md
+++ b/docs/superpowers/plans/2026-03-15-update-vuepress.md
@@ -1,0 +1,366 @@
+# Update VuePress Monorepo Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Update all `vuepress` and `@vuepress/*` package range pins in `package.json` to match their currently-installed versions, in a dedicated git worktree, and open a PR targeting `develop`.
+
+**Architecture:** Create an isolated git worktree from `develop`, bump all 8 VuePress-related version ranges in `package.json`, reinstall dependencies, verify with lint and build, commit, and open a PR.
+
+**Tech Stack:** git worktrees, pnpm, VuePress 2
+
+---
+
+## Task 1: Create the git worktree
+
+A git worktree lets you check out a branch into a separate directory without disturbing your main working tree. All commands in this task run from the **main repo root**.
+
+- [ ] Ensure the worktrees base directory exists:
+
+  ```sh
+  mkdir -p /Users/ansidev/git-worktrees/awesome-nuxt
+  ```
+
+- [ ] Create the worktree and a new branch `chore/update-vuepress` based on `develop`:
+
+  ```sh
+  cd /Users/ansidev/projects/personal/awesome-nuxt
+  git worktree add /Users/ansidev/git-worktrees/awesome-nuxt/update-vuepress -b chore/update-vuepress develop
+  ```
+
+  Expected output:
+
+  ```
+  Preparing worktree (new branch 'chore/update-vuepress')
+  branch 'chore/update-vuepress' set up to track 'develop'.
+  HEAD is now at <commit-hash> <latest commit message>
+  ```
+
+- [ ] Confirm the worktree was created and the branch is correct:
+
+  ```sh
+  git worktree list
+  ```
+
+  Expected: a line for `/Users/ansidev/git-worktrees/awesome-nuxt/update-vuepress` showing branch `chore/update-vuepress`.
+
+---
+
+## Task 2: Update version ranges in `package.json`
+
+All remaining commands run from **inside the worktree directory** unless stated otherwise.
+
+```sh
+cd /Users/ansidev/git-worktrees/awesome-nuxt/update-vuepress
+```
+
+Open `package.json` and apply the following 8 changes. The file is at:
+
+```
+/Users/ansidev/git-worktrees/awesome-nuxt/update-vuepress/package.json
+```
+
+- [ ] Update `vuepress`:
+
+  ```diff
+  - "vuepress": "^2.0.0-rc.19"
+  + "vuepress": "^2.0.0-rc.26"
+  ```
+
+- [ ] Update `@vuepress/bundler-vite`:
+
+  ```diff
+  - "@vuepress/bundler-vite": "^2.0.0-rc.19"
+  + "@vuepress/bundler-vite": "^2.0.0-rc.26"
+  ```
+
+- [ ] Update `@vuepress/client`:
+
+  ```diff
+  - "@vuepress/client": "^2.0.0-rc.19"
+  + "@vuepress/client": "^2.0.0-rc.26"
+  ```
+
+- [ ] Update `@vuepress/plugin-docsearch`:
+
+  ```diff
+  - "@vuepress/plugin-docsearch": "^2.0.0-rc.67"
+  + "@vuepress/plugin-docsearch": "^2.0.0-rc.125"
+  ```
+
+- [ ] Update `@vuepress/plugin-git`:
+
+  ```diff
+  - "@vuepress/plugin-git": "^2.0.0-rc.66"
+  + "@vuepress/plugin-git": "^2.0.0-rc.125"
+  ```
+
+- [ ] Update `@vuepress/plugin-google-analytics`:
+
+  ```diff
+  - "@vuepress/plugin-google-analytics": "^2.0.0-rc.66"
+  + "@vuepress/plugin-google-analytics": "^2.0.0-rc.125"
+  ```
+
+- [ ] Update `@vuepress/plugin-pwa`:
+
+  ```diff
+  - "@vuepress/plugin-pwa": "^2.0.0-rc.66"
+  + "@vuepress/plugin-pwa": "^2.0.0-rc.125"
+  ```
+
+- [ ] Update `@vuepress/theme-default`:
+
+  ```diff
+  - "@vuepress/theme-default": "^2.0.0-rc.66"
+  + "@vuepress/theme-default": "^2.0.0-rc.125"
+  ```
+
+- [ ] Verify the diff looks correct before proceeding:
+
+  ```sh
+  git diff package.json
+  ```
+
+  Confirm all 8 version range changes are present and no other lines were modified.
+
+---
+
+## Task 3: Run `pnpm install`
+
+Running `pnpm install` after a range-pin change updates the specifier recorded in `pnpm-lock.yaml` without actually changing the resolved versions (since the currently-installed versions already satisfy the new ranges).
+
+- [ ] Run install from the worktree directory:
+
+  ```sh
+  cd /Users/ansidev/git-worktrees/awesome-nuxt/update-vuepress
+  pnpm install
+  ```
+
+  Expected output: pnpm reports the lockfile was updated. The resolved package versions for all 8 packages should remain unchanged (only the specifier fields in `pnpm-lock.yaml` will change to reflect the new ranges).
+
+- [ ] Confirm the lockfile was updated with the new specifiers:
+
+  ```sh
+  git diff pnpm-lock.yaml | grep -E "^\+.*specifier"
+  ```
+
+  Expected: 8 lines showing the updated specifiers, e.g.:
+
+  ```
+  +    specifier: ^2.0.0-rc.26
+  +    specifier: ^2.0.0-rc.125
+  ```
+
+  (The `version:` lines should be unchanged.)
+
+---
+
+## Task 4: Run `pnpm lint`
+
+- [ ] Run the linter:
+
+  ```sh
+  cd /Users/ansidev/git-worktrees/awesome-nuxt/update-vuepress
+  pnpm lint
+  ```
+
+  This runs: `markdownlint-cli2 ./content/**/*.md`
+
+  Expected output: The command exits with code 0 and reports 0 errors. Example:
+
+  ```
+  markdownlint-cli2 v0.x.x (markdownlint vX.X.X)
+  Finding: ./content/**/*.md
+  Linting: X file(s)
+  Summary: 0 error(s) found
+  ```
+
+  If errors are reported: This is unexpected since no Markdown files were changed. Investigate whether any pre-existing lint issues exist before continuing.
+
+---
+
+## Task 5: Run `pnpm build`
+
+- [ ] Run the VuePress build:
+
+  ```sh
+  cd /Users/ansidev/git-worktrees/awesome-nuxt/update-vuepress
+  pnpm build
+  ```
+
+  This runs: `vuepress build content`
+
+  Expected output: Build completes successfully with no errors. The final lines should resemble:
+
+  ```
+  ✔ Initializing and preparing data - done
+  ✔ Compiling with vite - client +Xs
+  ✔ Compiling with vite - server +Xs
+  ✔ Rendering pages - done
+  ```
+
+  If the build fails:
+  1. Note the exact error message.
+  2. Check the VuePress 2 changelog for breaking changes between `rc.19` and `rc.26` (or between the plugin versions): https://github.com/vuepress/vuepress-next/blob/main/CHANGELOG.md
+  3. Apply any required configuration or code changes before continuing.
+  4. Re-run `pnpm build` until it passes.
+
+---
+
+## Task 6: Commit the changes
+
+- [ ] Stage both changed files:
+
+  ```sh
+  cd /Users/ansidev/git-worktrees/awesome-nuxt/update-vuepress
+  git add package.json pnpm-lock.yaml
+  ```
+
+- [ ] Verify the staged files are exactly `package.json` and `pnpm-lock.yaml` (no unintended files):
+
+  ```sh
+  git status
+  ```
+
+  Expected:
+
+  ```
+  On branch chore/update-vuepress
+  Changes to be committed:
+    (use "git restore --staged <file>..." to unstage)
+          modified:   package.json
+          modified:   pnpm-lock.yaml
+  ```
+
+- [ ] Create the commit with the exact message below:
+
+  ```sh
+  git commit -m "$(cat <<'EOF'
+  chore(deps): update vuepress monorepo
+
+  - vuepress: ^2.0.0-rc.19 → ^2.0.0-rc.26
+  - @vuepress/bundler-vite: ^2.0.0-rc.19 → ^2.0.0-rc.26
+  - @vuepress/client: ^2.0.0-rc.19 → ^2.0.0-rc.26
+  - @vuepress/plugin-docsearch: ^2.0.0-rc.67 → ^2.0.0-rc.125
+  - @vuepress/plugin-git: ^2.0.0-rc.66 → ^2.0.0-rc.125
+  - @vuepress/plugin-google-analytics: ^2.0.0-rc.66 → ^2.0.0-rc.125
+  - @vuepress/plugin-pwa: ^2.0.0-rc.66 → ^2.0.0-rc.125
+  - @vuepress/theme-default: ^2.0.0-rc.66 → ^2.0.0-rc.125
+  EOF
+  )"
+  ```
+
+  Expected output:
+
+  ```
+  [chore/update-vuepress <hash>] chore(deps): update vuepress monorepo
+   2 files changed, X insertions(+), X deletions(-)
+  ```
+
+---
+
+## Task 7: Push the branch and open a pull request
+
+- [ ] Push the branch to the remote:
+
+  ```sh
+  cd /Users/ansidev/git-worktrees/awesome-nuxt/update-vuepress
+  git push -u origin chore/update-vuepress
+  ```
+
+  Expected output:
+
+  ```
+  To https://github.com/ansidev/awesome-nuxt.git
+   * [new branch]      chore/update-vuepress -> chore/update-vuepress
+  branch 'chore/update-vuepress' set up to track 'origin/chore/update-vuepress'.
+  ```
+
+- [ ] Open a pull request targeting `develop` using the GitHub CLI:
+
+  ```sh
+  gh pr create \
+    --base develop \
+    --head chore/update-vuepress \
+    --title "chore(deps): update vuepress monorepo" \
+    --body "$(cat <<'EOF'
+  ## Summary
+
+  - Updates all `vuepress` and `@vuepress/*` package range pins in `package.json` to prevent future installs from resolving to older versions.
+  - The resolved versions in the lockfile are unchanged; only the range specifiers are updated.
+
+  ## Changes
+
+  | Package | Old range | New range |
+  |---|---|---|
+  | `vuepress` | `^2.0.0-rc.19` | `^2.0.0-rc.26` |
+  | `@vuepress/bundler-vite` | `^2.0.0-rc.19` | `^2.0.0-rc.26` |
+  | `@vuepress/client` | `^2.0.0-rc.19` | `^2.0.0-rc.26` |
+  | `@vuepress/plugin-docsearch` | `^2.0.0-rc.67` | `^2.0.0-rc.125` |
+  | `@vuepress/plugin-git` | `^2.0.0-rc.66` | `^2.0.0-rc.125` |
+  | `@vuepress/plugin-google-analytics` | `^2.0.0-rc.66` | `^2.0.0-rc.125` |
+  | `@vuepress/plugin-pwa` | `^2.0.0-rc.66` | `^2.0.0-rc.125` |
+  | `@vuepress/theme-default` | `^2.0.0-rc.66` | `^2.0.0-rc.125` |
+
+  ## Test plan
+
+  - [ ] `pnpm lint` passes with 0 errors
+  - [ ] `pnpm build` completes successfully
+  EOF
+  )"
+  ```
+
+  Expected output: a URL to the newly opened pull request, e.g.:
+
+  ```
+  https://github.com/ansidev/awesome-nuxt/pull/XXX
+  ```
+
+---
+
+## Task 8: Teardown after merge
+
+Once the pull request has been merged into `develop`, clean up the worktree and local branch. These commands run from the **main repo root**.
+
+- [ ] Switch to the main repo root:
+
+  ```sh
+  cd /Users/ansidev/projects/personal/awesome-nuxt
+  ```
+
+- [ ] Fetch the latest remote state to confirm the merge:
+
+  ```sh
+  git fetch origin
+  git log origin/develop --oneline -5
+  ```
+
+  Confirm the merge commit for `chore/update-vuepress` appears in the log.
+
+- [ ] Remove the worktree directory:
+
+  ```sh
+  git worktree remove /Users/ansidev/git-worktrees/awesome-nuxt/update-vuepress
+  ```
+
+  Expected output: no output (silent success). The directory `/Users/ansidev/git-worktrees/awesome-nuxt/update-vuepress` will be deleted.
+
+- [ ] Delete the local branch:
+
+  ```sh
+  git branch -d chore/update-vuepress
+  ```
+
+  Expected output:
+
+  ```
+  Deleted branch chore/update-vuepress (was <hash>).
+  ```
+
+  Note: `-d` (lowercase) is safe — it refuses to delete the branch if it has not been fully merged. If you see an error about the branch not being merged, verify the PR was actually merged (not just closed) before forcing with `-D`.
+
+- [ ] Optionally prune the remote-tracking reference:
+
+  ```sh
+  git remote prune origin
+  ```

--- a/docs/superpowers/specs/2026-03-15-dependency-updates-design.md
+++ b/docs/superpowers/specs/2026-03-15-dependency-updates-design.md
@@ -71,9 +71,9 @@ Each worktree follows the same steps:
 - There is no limit on the number of files to fix — the `content/` directory has only 16 markdown files, so scope is bounded
 - To diagnose *why* rules changed, consult the [markdownlint-cli2 changelog](https://github.com/DavidAnson/markdownlint-cli2/blob/main/CHANGELOG.md) and the [markdownlint changelog](https://github.com/DavidAnson/markdownlint/blob/main/CHANGELOG.md). New violations may require either fixing content files or updating rules in `.markdownlint-cli2.cjs`
 
-### Build verification for VuePress group
+### Build verification
 
-In the `update-vuepress` worktree, also run `pnpm build` after `pnpm lint` to catch any VuePress API breakage that lint cannot detect. If `pnpm build` fails, investigate the VuePress changelog before proceeding.
+Run `pnpm build` in every worktree after `pnpm lint` passes. This catches runtime or bundler breakage that lint cannot detect. If `pnpm build` fails in the `update-vuepress` worktree, investigate the VuePress changelog before proceeding.
 
 ## GitHub Actions
 
@@ -81,12 +81,14 @@ No workflow file changes are required. All workflows already use `actions/checko
 
 ## Verification
 
+All worktrees run both `pnpm lint` and `pnpm build` locally before committing.
+
 | Worktree | Commands |
 |---|---|
-| `update-vue` | `pnpm lint` |
-| `update-sass` | `pnpm lint` |
+| `update-vue` | `pnpm lint` && `pnpm build` |
+| `update-sass` | `pnpm lint` && `pnpm build` |
 | `update-vuepress` | `pnpm lint` && `pnpm build` |
-| `update-markdownlint` | `pnpm lint` |
+| `update-markdownlint` | `pnpm lint` && `pnpm build` |
 
 Current baseline: `pnpm lint` passes with 0 errors.
 

--- a/docs/superpowers/specs/2026-03-15-dependency-updates-design.md
+++ b/docs/superpowers/specs/2026-03-15-dependency-updates-design.md
@@ -1,0 +1,81 @@
+# Dependency Updates Design
+
+**Date:** 2026-03-15
+
+## Goal
+
+Update all outdated npm dependencies in the awesome-nuxt project using parallel git worktrees — one worktree per logical dependency group — to allow independent, reviewable updates.
+
+## Context
+
+The project is a VuePress-based static site (`pnpm` workspace) with 11 `devDependencies`. Currently on branch `develop`. Renovate has been handling updates historically (see commit history); this plan mirrors that style manually.
+
+**Current outdated packages:**
+
+| Package | Installed | Target |
+|---|---|---|
+| `vue` | 3.5.13 | 3.5.30 |
+| `sass-embedded` | 1.87.0 | 1.98.0 |
+| `vuepress` | 2.0.0-rc.22 | 2.0.0-rc.26 |
+| `@vuepress/bundler-vite` | 2.0.0-rc.22 | 2.0.0-rc.26 |
+| `@vuepress/client` | 2.0.0-rc.22 | 2.0.0-rc.26 |
+| `@vuepress/plugin-docsearch` | 2.0.0-rc.99 | 2.0.0-rc.125 |
+| `@vuepress/plugin-git` | 2.0.0-rc.99 | 2.0.0-rc.125 |
+| `@vuepress/plugin-google-analytics` | 2.0.0-rc.98 | 2.0.0-rc.125 |
+| `@vuepress/plugin-pwa` | 2.0.0-rc.99 | 2.0.0-rc.125 |
+| `@vuepress/theme-default` | 2.0.0-rc.101 | 2.0.0-rc.125 |
+| `markdownlint-cli2` | 0.17.2 | 0.21.0 |
+
+## Architecture
+
+Four parallel git worktrees are created under `/Users/ansidev/git-worktrees/awesome-nuxt/`, each branched from `develop`. Each worktree handles one logical group of packages, installs dependencies, verifies with `pnpm lint`, and produces a PR targeting `develop`.
+
+The `@vuepress/*` packages and `vuepress` are updated together in a single worktree because they are tightly coupled and must stay in sync.
+
+## Worktree Map
+
+| Worktree path | Branch | Packages |
+|---|---|---|
+| `.../update-vue` | `chore/update-vue` | `vue` → 3.5.30 |
+| `.../update-sass` | `chore/update-sass-embedded` | `sass-embedded` → 1.98.0 |
+| `.../update-vuepress` | `chore/update-vuepress` | `vuepress` + all `@vuepress/*` → latest rc |
+| `.../update-markdownlint` | `chore/update-markdownlint-cli2` | `markdownlint-cli2` → 0.21.0 |
+
+## Per-Worktree Workflow
+
+Each worktree follows the same steps:
+
+1. Create worktree with a dedicated branch from `develop`
+2. Edit `package.json` — bump the target package version(s)
+3. Run `pnpm install` to regenerate `pnpm-lock.yaml`
+4. Run `pnpm lint` to verify no regressions
+   - If `markdownlint-cli2` update introduces new rule violations, fix the affected markdown files in the same commit or a follow-up commit in the same worktree
+5. Commit using the project's established style: `chore(deps): update dependency <name> to <version>`
+6. Open a PR targeting `develop`
+
+## GitHub Actions
+
+No workflow file changes are required. All workflows already use `actions/checkout@v6`. The build/deploy workflow delegates to `ghacts/static-site@main`, which dynamically resolves Node.js and pnpm versions — no pins to update.
+
+## Verification
+
+- **`pnpm lint`** — the only test in this project (`markdownlint-cli2 ./content/**/*.md`)
+- Current baseline: 0 errors
+- Each worktree must pass lint before committing
+
+## Commit Style
+
+Matches existing Renovate-generated history:
+
+```
+chore(deps): update dependency vue to v3.5.30
+chore(deps): update dependency sass-embedded to v1.98.0
+chore(deps): update vuepress
+chore(deps): update dependency markdownlint-cli2 to v0.21.0
+```
+
+## Out of Scope
+
+- GitHub Actions workflow version bumps (already current)
+- Node.js or pnpm engine version changes
+- Any content changes unrelated to lint fixes

--- a/docs/superpowers/specs/2026-03-15-dependency-updates-design.md
+++ b/docs/superpowers/specs/2026-03-15-dependency-updates-design.md
@@ -10,27 +10,31 @@ Update all outdated npm dependencies in the awesome-nuxt project using parallel 
 
 The project is a VuePress-based static site (`pnpm` workspace) with 11 `devDependencies`. Currently on branch `develop`. Renovate has been handling updates historically (see commit history); this plan mirrors that style manually.
 
-**Current outdated packages:**
+**Current package state** (resolved versions from `pnpm-lock.yaml`):
 
-| Package | Installed | Target |
-|---|---|---|
-| `vue` | 3.5.13 | 3.5.30 |
-| `sass-embedded` | 1.87.0 | 1.98.0 |
-| `vuepress` | 2.0.0-rc.22 | 2.0.0-rc.26 |
-| `@vuepress/bundler-vite` | 2.0.0-rc.22 | 2.0.0-rc.26 |
-| `@vuepress/client` | 2.0.0-rc.22 | 2.0.0-rc.26 |
-| `@vuepress/plugin-docsearch` | 2.0.0-rc.99 | 2.0.0-rc.125 |
-| `@vuepress/plugin-git` | 2.0.0-rc.99 | 2.0.0-rc.125 |
-| `@vuepress/plugin-google-analytics` | 2.0.0-rc.98 | 2.0.0-rc.125 |
-| `@vuepress/plugin-pwa` | 2.0.0-rc.99 | 2.0.0-rc.125 |
-| `@vuepress/theme-default` | 2.0.0-rc.101 | 2.0.0-rc.125 |
-| `markdownlint-cli2` | 0.17.2 | 0.21.0 |
+| Package | `package.json` range | Installed | Target |
+|---|---|---|---|
+| `vue` | `^3.5.13` | 3.5.29 | 3.5.30 |
+| `sass-embedded` | `^1.83.0` | 1.97.3 | 1.98.0 |
+| `vuepress` | `^2.0.0-rc.19` | 2.0.0-rc.26 | already at rc.26 — update range pin |
+| `@vuepress/bundler-vite` | `^2.0.0-rc.19` | 2.0.0-rc.26 | update range pin |
+| `@vuepress/client` | `^2.0.0-rc.19` | 2.0.0-rc.26 | update range pin |
+| `@vuepress/plugin-docsearch` | `^2.0.0-rc.67` | 2.0.0-rc.125 | update range pin |
+| `@vuepress/plugin-git` | `^2.0.0-rc.66` | 2.0.0-rc.125 | update range pin |
+| `@vuepress/plugin-google-analytics` | `^2.0.0-rc.66` | 2.0.0-rc.125 | update range pin |
+| `@vuepress/plugin-pwa` | `^2.0.0-rc.66` | 2.0.0-rc.125 | update range pin |
+| `@vuepress/theme-default` | `^2.0.0-rc.66` | 2.0.0-rc.125 | update range pin |
+| `markdownlint-cli2` | `^0.18.0` | 0.18.1 | 0.21.0 |
+
+> **Note on `@vuepress/*` packages:** The lockfile already resolves all `@vuepress/*` packages to rc.125/rc.26 because the semver ranges already satisfy those versions. The `package.json` range pins (e.g. `^2.0.0-rc.66`) need to be updated to reflect the actual installed baseline, preventing future installs from resolving to older versions.
 
 ## Architecture
 
-Four parallel git worktrees are created under `/Users/ansidev/git-worktrees/awesome-nuxt/`, each branched from `develop`. Each worktree handles one logical group of packages, installs dependencies, verifies with `pnpm lint`, and produces a PR targeting `develop`.
+Four parallel git worktrees are created under `/Users/ansidev/git-worktrees/awesome-nuxt/` (this is the author's local path — substitute your own base directory). Each worktree branches from `develop`, updates its package group, verifies, and opens a PR targeting `develop`.
 
 The `@vuepress/*` packages and `vuepress` are updated together in a single worktree because they are tightly coupled and must stay in sync.
+
+**Merge order:** Since all four worktrees modify `pnpm-lock.yaml`, merge them one at a time. After each PR merges into `develop`, rebase the remaining open branches onto the updated `develop`. `pnpm-lock.yaml` will have a merge conflict that git cannot auto-resolve — resolve it by deleting the conflicted lockfile and running `pnpm install` to regenerate it cleanly, then stage the result and continue the rebase. Re-run `pnpm lint` (and `pnpm build` for the vuepress branch) after each rebase before pushing. The `rebase.yaml` workflow supports `/rebase` comments on PRs for convenience (automated rebase still requires manual lockfile regeneration if conflicts arise).
 
 ## Worktree Map
 
@@ -38,20 +42,38 @@ The `@vuepress/*` packages and `vuepress` are updated together in a single workt
 |---|---|---|
 | `.../update-vue` | `chore/update-vue` | `vue` → 3.5.30 |
 | `.../update-sass` | `chore/update-sass-embedded` | `sass-embedded` → 1.98.0 |
-| `.../update-vuepress` | `chore/update-vuepress` | `vuepress` + all `@vuepress/*` → latest rc |
+| `.../update-vuepress` | `chore/update-vuepress` | `vuepress` + all `@vuepress/*` range pins |
 | `.../update-markdownlint` | `chore/update-markdownlint-cli2` | `markdownlint-cli2` → 0.21.0 |
 
 ## Per-Worktree Workflow
 
 Each worktree follows the same steps:
 
-1. Create worktree with a dedicated branch from `develop`
-2. Edit `package.json` — bump the target package version(s)
+1. Create worktree with a dedicated branch from `develop`:
+   ```bash
+   git worktree add /Users/ansidev/git-worktrees/awesome-nuxt/<name> -b <branch>
+   ```
+2. Edit `package.json` — bump the target package version range(s)
 3. Run `pnpm install` to regenerate `pnpm-lock.yaml`
 4. Run `pnpm lint` to verify no regressions
-   - If `markdownlint-cli2` update introduces new rule violations, fix the affected markdown files in the same commit or a follow-up commit in the same worktree
-5. Commit using the project's established style: `chore(deps): update dependency <name> to <version>`
+5. Commit — see **Commit Style** below
 6. Open a PR targeting `develop`
+7. After PR merges: remove the worktree and local branch:
+   ```bash
+   git worktree remove /Users/ansidev/git-worktrees/awesome-nuxt/<name>
+   git branch -d <branch>
+   ```
+
+### If `pnpm lint` fails (markdownlint violations)
+
+- Fix the offending markdown files in a **separate commit** from the version bump, so reviewers can distinguish lint fixes from the dependency change
+- Include in the PR description which markdown rules changed and which files were fixed
+- There is no limit on the number of files to fix — the `content/` directory has only 16 markdown files, so scope is bounded
+- To diagnose *why* rules changed, consult the [markdownlint-cli2 changelog](https://github.com/DavidAnson/markdownlint-cli2/blob/main/CHANGELOG.md) and the [markdownlint changelog](https://github.com/DavidAnson/markdownlint/blob/main/CHANGELOG.md). New violations may require either fixing content files or updating rules in `.markdownlint-cli2.cjs`
+
+### Build verification for VuePress group
+
+In the `update-vuepress` worktree, also run `pnpm build` after `pnpm lint` to catch any VuePress API breakage that lint cannot detect. If `pnpm build` fails, investigate the VuePress changelog before proceeding.
 
 ## GitHub Actions
 
@@ -59,23 +81,38 @@ No workflow file changes are required. All workflows already use `actions/checko
 
 ## Verification
 
-- **`pnpm lint`** — the only test in this project (`markdownlint-cli2 ./content/**/*.md`)
-- Current baseline: 0 errors
-- Each worktree must pass lint before committing
+| Worktree | Commands |
+|---|---|
+| `update-vue` | `pnpm lint` |
+| `update-sass` | `pnpm lint` |
+| `update-vuepress` | `pnpm lint` && `pnpm build` |
+| `update-markdownlint` | `pnpm lint` |
+
+Current baseline: `pnpm lint` passes with 0 errors.
 
 ## Commit Style
 
-Matches existing Renovate-generated history:
-
+Matches existing Renovate-generated history. Each commit message uses the format:
 ```
-chore(deps): update dependency vue to v3.5.30
-chore(deps): update dependency sass-embedded to v1.98.0
-chore(deps): update vuepress
-chore(deps): update dependency markdownlint-cli2 to v0.21.0
+chore(deps): update dependency <name> to v<version>
+```
+
+For the vuepress group (multiple packages in one commit), list all updated packages in the commit body:
+```
+chore(deps): update vuepress monorepo
+
+- vuepress: ^2.0.0-rc.19 → ^2.0.0-rc.26
+- @vuepress/bundler-vite: ^2.0.0-rc.19 → ^2.0.0-rc.26
+- @vuepress/client: ^2.0.0-rc.19 → ^2.0.0-rc.26
+- @vuepress/plugin-docsearch: ^2.0.0-rc.67 → ^2.0.0-rc.125
+- @vuepress/plugin-git: ^2.0.0-rc.66 → ^2.0.0-rc.125
+- @vuepress/plugin-google-analytics: ^2.0.0-rc.66 → ^2.0.0-rc.125
+- @vuepress/plugin-pwa: ^2.0.0-rc.66 → ^2.0.0-rc.125
+- @vuepress/theme-default: ^2.0.0-rc.66 → ^2.0.0-rc.125
 ```
 
 ## Out of Scope
 
 - GitHub Actions workflow version bumps (already current)
 - Node.js or pnpm engine version changes
-- Any content changes unrelated to lint fixes
+- Any content changes unrelated to lint fixes triggered by the `markdownlint-cli2` update

--- a/package.json
+++ b/package.json
@@ -31,17 +31,17 @@
     "test": "pnpm lint"
   },
   "devDependencies": {
-    "@vuepress/bundler-vite": "^2.0.0-rc.19",
-    "@vuepress/client": "^2.0.0-rc.19",
-    "@vuepress/plugin-docsearch": "^2.0.0-rc.67",
-    "@vuepress/plugin-git": "^2.0.0-rc.66",
-    "@vuepress/plugin-google-analytics": "^2.0.0-rc.66",
-    "@vuepress/plugin-pwa": "^2.0.0-rc.66",
-    "@vuepress/theme-default": "^2.0.0-rc.66",
+    "@vuepress/bundler-vite": "^2.0.0-rc.26",
+    "@vuepress/client": "^2.0.0-rc.26",
+    "@vuepress/plugin-docsearch": "^2.0.0-rc.125",
+    "@vuepress/plugin-git": "^2.0.0-rc.125",
+    "@vuepress/plugin-google-analytics": "^2.0.0-rc.125",
+    "@vuepress/plugin-pwa": "^2.0.0-rc.125",
+    "@vuepress/theme-default": "^2.0.0-rc.125",
     "markdownlint-cli2": "^0.18.0",
     "sass-embedded": "^1.83.0",
     "vue": "^3.5.13",
-    "vuepress": "^2.0.0-rc.19"
+    "vuepress": "^2.0.0-rc.26"
   },
   "packageManager": "pnpm@10.30.3"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,25 +9,25 @@ importers:
   .:
     devDependencies:
       '@vuepress/bundler-vite':
-        specifier: ^2.0.0-rc.19
+        specifier: ^2.0.0-rc.26
         version: 2.0.0-rc.26(@types/node@25.3.5)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(yaml@2.6.1)
       '@vuepress/client':
-        specifier: ^2.0.0-rc.19
+        specifier: ^2.0.0-rc.26
         version: 2.0.0-rc.26
       '@vuepress/plugin-docsearch':
-        specifier: ^2.0.0-rc.67
+        specifier: ^2.0.0-rc.125
         version: 2.0.0-rc.125(@vuepress/bundler-vite@2.0.0-rc.26(@types/node@25.3.5)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(yaml@2.6.1))(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.26(@types/node@25.3.5)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(yaml@2.6.1))(vue@3.5.29))
       '@vuepress/plugin-git':
-        specifier: ^2.0.0-rc.66
+        specifier: ^2.0.0-rc.125
         version: 2.0.0-rc.125(@vuepress/bundler-vite@2.0.0-rc.26(@types/node@25.3.5)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(yaml@2.6.1))(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.26(@types/node@25.3.5)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(yaml@2.6.1))(vue@3.5.29))
       '@vuepress/plugin-google-analytics':
-        specifier: ^2.0.0-rc.66
+        specifier: ^2.0.0-rc.125
         version: 2.0.0-rc.125(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.26(@types/node@25.3.5)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(yaml@2.6.1))(vue@3.5.29))
       '@vuepress/plugin-pwa':
-        specifier: ^2.0.0-rc.66
+        specifier: ^2.0.0-rc.125
         version: 2.0.0-rc.125(@vuepress/bundler-vite@2.0.0-rc.26(@types/node@25.3.5)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(yaml@2.6.1))(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.26(@types/node@25.3.5)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(yaml@2.6.1))(vue@3.5.29))
       '@vuepress/theme-default':
-        specifier: ^2.0.0-rc.66
+        specifier: ^2.0.0-rc.125
         version: 2.0.0-rc.125(@vuepress/bundler-vite@2.0.0-rc.26(@types/node@25.3.5)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(yaml@2.6.1))(markdown-it@14.1.1)(sass-embedded@1.97.3)(sass@1.97.3)(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.26(@types/node@25.3.5)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(yaml@2.6.1))(vue@3.5.29))
       markdownlint-cli2:
         specifier: ^0.18.0
@@ -39,7 +39,7 @@ importers:
         specifier: ^3.5.13
         version: 3.5.29
       vuepress:
-        specifier: ^2.0.0-rc.19
+        specifier: ^2.0.0-rc.26
         version: 2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.26(@types/node@25.3.5)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(yaml@2.6.1))(vue@3.5.29)
 
 packages:
@@ -4266,7 +4266,7 @@ snapshots:
 
   '@types/sax@1.2.7':
     dependencies:
-      '@types/node': 24.12.0
+      '@types/node': 25.3.5
 
   '@types/trusted-types@2.0.7': {}
 


### PR DESCRIPTION
## Summary

- Bumps range pins for all VuePress packages:
  - \`@vuepress/bundler-vite\`: \`^2.0.0-rc.19\` → \`^2.0.0-rc.26\`
  - \`@vuepress/client\`: \`^2.0.0-rc.19\` → \`^2.0.0-rc.26\`
  - \`@vuepress/plugin-docsearch\`: \`^2.0.0-rc.67\` → \`^2.0.0-rc.125\`
  - \`@vuepress/plugin-git\`: \`^2.0.0-rc.66\` → \`^2.0.0-rc.125\`
  - \`@vuepress/plugin-google-analytics\`: \`^2.0.0-rc.66\` → \`^2.0.0-rc.125\`
  - \`@vuepress/plugin-pwa\`: \`^2.0.0-rc.66\` → \`^2.0.0-rc.125\`
  - \`@vuepress/theme-default\`: \`^2.0.0-rc.66\` → \`^2.0.0-rc.125\`
  - \`vuepress\`: \`^2.0.0-rc.19\` → \`^2.0.0-rc.26\`
- Lockfile specifier fields updated; resolved versions were already at target
- No new lint violations introduced by the version bump

## Test plan

- [x] \`pnpm lint\` exits with 0 errors
- [x] \`pnpm build\` completes successfully