### PR TITLE
chore(deps): update vuepress monorepo

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,17 +31,17 @@
     "test": "pnpm lint"
   },
   "devDependencies": {
-    "@vuepress/bundler-vite": "^2.0.0-rc.19",
-    "@vuepress/client": "^2.0.0-rc.19",
-    "@vuepress/plugin-docsearch": "^2.0.0-rc.67",
-    "@vuepress/plugin-git": "^2.0.0-rc.66",
-    "@vuepress/plugin-google-analytics": "^2.0.0-rc.66",
-    "@vuepress/plugin-pwa": "^2.0.0-rc.66",
-    "@vuepress/theme-default": "^2.0.0-rc.66",
+    "@vuepress/bundler-vite": "^2.0.0-rc.26",
+    "@vuepress/client": "^2.0.0-rc.26",
+    "@vuepress/plugin-docsearch": "^2.0.0-rc.125",
+    "@vuepress/plugin-git": "^2.0.0-rc.125",
+    "@vuepress/plugin-google-analytics": "^2.0.0-rc.125",
+    "@vuepress/plugin-pwa": "^2.0.0-rc.125",
+    "@vuepress/theme-default": "^2.0.0-rc.125",
     "markdownlint-cli2": "^0.21.0",
     "sass-embedded": "^1.98.0",
     "vue": "^3.5.30",
-    "vuepress": "^2.0.0-rc.19"
+    "vuepress": "^2.0.0-rc.26"
   },
   "packageManager": "pnpm@10.30.3"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,25 +9,25 @@ importers:
   .:
     devDependencies:
       '@vuepress/bundler-vite':
-        specifier: ^2.0.0-rc.19
+        specifier: ^2.0.0-rc.26
         version: 2.0.0-rc.26(@types/node@25.3.5)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.0)(yaml@2.6.1)
       '@vuepress/client':
-        specifier: ^2.0.0-rc.19
+        specifier: ^2.0.0-rc.26
         version: 2.0.0-rc.26
       '@vuepress/plugin-docsearch':
-        specifier: ^2.0.0-rc.67
+        specifier: ^2.0.0-rc.125
         version: 2.0.0-rc.125(@vuepress/bundler-vite@2.0.0-rc.26(@types/node@25.3.5)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.0)(yaml@2.6.1))(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.26(@types/node@25.3.5)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.0)(yaml@2.6.1))(vue@3.5.30))
       '@vuepress/plugin-git':
-        specifier: ^2.0.0-rc.66
+        specifier: ^2.0.0-rc.125
         version: 2.0.0-rc.125(@vuepress/bundler-vite@2.0.0-rc.26(@types/node@25.3.5)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.0)(yaml@2.6.1))(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.26(@types/node@25.3.5)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.0)(yaml@2.6.1))(vue@3.5.30))
       '@vuepress/plugin-google-analytics':
-        specifier: ^2.0.0-rc.66
+        specifier: ^2.0.0-rc.125
         version: 2.0.0-rc.125(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.26(@types/node@25.3.5)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.0)(yaml@2.6.1))(vue@3.5.30))
       '@vuepress/plugin-pwa':
-        specifier: ^2.0.0-rc.66
+        specifier: ^2.0.0-rc.125
         version: 2.0.0-rc.125(@vuepress/bundler-vite@2.0.0-rc.26(@types/node@25.3.5)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.0)(yaml@2.6.1))(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.26(@types/node@25.3.5)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.0)(yaml@2.6.1))(vue@3.5.30))
       '@vuepress/theme-default':
-        specifier: ^2.0.0-rc.66
+        specifier: ^2.0.0-rc.125
         version: 2.0.0-rc.125(@vuepress/bundler-vite@2.0.0-rc.26(@types/node@25.3.5)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.0)(yaml@2.6.1))(markdown-it@14.1.1)(sass-embedded@1.98.0)(sass@1.98.0)(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.26(@types/node@25.3.5)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.0)(yaml@2.6.1))(vue@3.5.30))
       markdownlint-cli2:
         specifier: ^0.21.0
@@ -39,7 +39,7 @@ importers:
         specifier: ^3.5.30
         version: 3.5.30
       vuepress:
-        specifier: ^2.0.0-rc.19
+        specifier: ^2.0.0-rc.26
         version: 2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.26(@types/node@25.3.5)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.0)(yaml@2.6.1))(vue@3.5.30)
 
 packages:
@@ -1214,9 +1214,6 @@ packages:
     resolution: {integrity: sha512-v+R34icapydRwbZRD0sXwtHqrQJv38JuMB4JxbOxd8NEpGLny7cncMp53W9UH/zo4j8eDHjQ1dEJXwzFQknjtQ==}
     peerDependencies:
       vue: 3.5.30
-
-  '@vue/shared@3.5.29':
-    resolution: {integrity: sha512-w7SR0A5zyRByL9XUkCfdLs7t9XOHUyJ67qPGQjOou3p6GvBeBW+AVjUUmlxtZ4PIYaRvE+1LmK44O4uajlZwcg==}
 
   '@vue/shared@3.5.30':
     resolution: {integrity: sha512-YXgQ7JjaO18NeK2K9VTbDHaFy62WrObMa6XERNfNOkAhD1F1oDSf3ZJ7K6GqabZ0BvSDHajp8qfS5Sa2I9n8uQ==}
@@ -4269,7 +4266,7 @@ snapshots:
 
   '@types/sax@1.2.7':
     dependencies:
-      '@types/node': 24.12.0
+      '@types/node': 25.3.5
 
   '@types/trusted-types@2.0.7': {}
 
@@ -4354,8 +4351,6 @@ snapshots:
       '@vue/shared': 3.5.30
       vue: 3.5.30
 
-  '@vue/shared@3.5.29': {}
-
   '@vue/shared@3.5.30': {}
 
   '@vuepress/bundler-vite@2.0.0-rc.26(@types/node@25.3.5)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.0)(yaml@2.6.1)':
@@ -4437,7 +4432,7 @@ snapshots:
 
   '@vuepress/helper@2.0.0-rc.125(@vuepress/bundler-vite@2.0.0-rc.26(@types/node@25.3.5)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.0)(yaml@2.6.1))(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.26(@types/node@25.3.5)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.0)(yaml@2.6.1))(vue@3.5.30))':
     dependencies:
-      '@vue/shared': 3.5.29
+      '@vue/shared': 3.5.30
       '@vueuse/core': 14.2.1(vue@3.5.30)
       cheerio: 1.2.0
       fflate: 0.8.2


### PR DESCRIPTION
## Summary

- Bumps range pins for all VuePress packages:
  - \`@vuepress/bundler-vite\`: \`^2.0.0-rc.19\` → \`^2.0.0-rc.26\`
  - \`@vuepress/client\`: \`^2.0.0-rc.19\` → \`^2.0.0-rc.26\`
  - \`@vuepress/plugin-docsearch\`: \`^2.0.0-rc.67\` → \`^2.0.0-rc.125\`
  - \`@vuepress/plugin-git\`: \`^2.0.0-rc.66\` → \`^2.0.0-rc.125\`
  - \`@vuepress/plugin-google-analytics\`: \`^2.0.0-rc.66\` → \`^2.0.0-rc.125\`
  - \`@vuepress/plugin-pwa\`: \`^2.0.0-rc.66\` → \`^2.0.0-rc.125\`
  - \`@vuepress/theme-default\`: \`^2.0.0-rc.66\` → \`^2.0.0-rc.125\`
  - \`vuepress\`: \`^2.0.0-rc.19\` → \`^2.0.0-rc.26\`
- Lockfile specifier fields updated; resolved versions were already at target
- No new lint violations introduced by the version bump

## Test plan

- [x] \`pnpm lint\` exits with 0 errors
- [x] \`pnpm build\` completes successfully