### PR TITLE
Add nuxt-i18n-micro to community modules

### DIFF
--- a/content/resources/modules.md
+++ b/content/resources/modules.md
@@ -172,3 +172,5 @@
 - [@nuxt-modules/cache](https://github.com/nuxt-modules/cache) - Browser and Server Cache module for Nuxt 3
 - [@nuxt-commerce/nuxt-tailvue](https://github.com/acidjazz/nuxt-tailvue) - Out of the box Tailwind CSS components
 - [nuxt-toastflow](https://github.com/adrianjanocko/toastflow/tree/main/packages/nuxt) - Headless toast (notification) engine for Nuxt (Vue 3 renderer, TS-first, CSS-first theming, highly customizable).
+
+- [nuxt-i18n-micro](https://github.com/s00d/nuxt-i18n-micro) - Lightweight, high-performance i18n module for Nuxt with strategy-based routing and minimal overhead.

--- a/content/resources/modules.md
+++ b/content/resources/modules.md
@@ -172,5 +172,4 @@
 - [@nuxt-modules/cache](https://github.com/nuxt-modules/cache) - Browser and Server Cache module for Nuxt 3
 - [@nuxt-commerce/nuxt-tailvue](https://github.com/acidjazz/nuxt-tailvue) - Out of the box Tailwind CSS components
 - [nuxt-toastflow](https://github.com/adrianjanocko/toastflow/tree/main/packages/nuxt) - Headless toast (notification) engine for Nuxt (Vue 3 renderer, TS-first, CSS-first theming, highly customizable).
-
 - [nuxt-i18n-micro](https://github.com/s00d/nuxt-i18n-micro) - Lightweight, high-performance i18n module for Nuxt with strategy-based routing and minimal overhead.


### PR DESCRIPTION
## Summary
- Add [nuxt-i18n-micro](https://github.com/s00d/nuxt-i18n-micro) to the Community modules list
- Lightweight, high-performance i18n for Nuxt with strategy-based routing (alternative to `@nuxtjs/i18n`)
- Listed on [nuxt.com/modules](https://nuxt.com/modules/i18n-micro), docs: https://s00d.github.io/nuxt-i18n-micro/

## Checklist
- [x] Added at the end of the relevant list
- [x] Nuxt-related, tested, and documented

Made with [Cursor](https://cursor.com)