### PR TITLE
Merge branch release/2.1.3 into develop

### DIFF
--- a/.changes/v2.1.3.md
+++ b/.changes/v2.1.3.md
@@ -1,0 +1,43 @@
+## [v2.1.3](https://github.com/ansidev/awesome-nuxt/compare/v2.1.2...v2.1.3) (2026-08-05)
+
+### Bug Fixes
+
+- only delete PR branch and environment after merged into develop
+
+- update GitHub workflows
+
+### Code Refactoring
+
+- **github-actions:** replace the existing deploy GitHub actions with one GitHub action
+
+### Documentations
+
+- add dependency update implementation plans
+
+- require pnpm build verification in all worktrees
+
+- update dependency updates spec based on review feedback
+
+- add dependency updates design spec
+
+### Features
+
+- **github-actions:** add gitflow for GitHub actions
+
+### Dependencies
+
+| Package                             | Version                             |
+| ----------------------------------- | ----------------------------------- |
+| `@vuepress/bundler-vite`            | `^2.0.0-rc.19` `->` `^2.0.0-rc.26`  |
+| `@vuepress/client`                  | `^2.0.0-rc.19` `->` `^2.0.0-rc.26`  |
+| `@vuepress/plugin-docsearch`        | `^2.0.0-rc.67` `->` `^2.0.0-rc.125` |
+| `@vuepress/plugin-git`              | `^2.0.0-rc.66` `->` `^2.0.0-rc.125` |
+| `@vuepress/plugin-google-analytics` | `^2.0.0-rc.66` `->` `^2.0.0-rc.125` |
+| `@vuepress/plugin-pwa`              | `^2.0.0-rc.66` `->` `^2.0.0-rc.125` |
+| `@vuepress/theme-default`           | `^2.0.0-rc.66` `->` `^2.0.0-rc.125` |
+| `markdownlint-cli2`                 | `^0.16.0` `->` `^0.22.0`            |
+| `sass-embedded`                     | `^1.83.0` `->` `^1.98.0`            |
+| `vue`                               | `^3.5.13` `->` `^3.5.30`            |
+| `vuepress`                          | `^2.0.0-rc.19` `->` `^2.0.0-rc.26`  |
+
+Full Changelog: [v2.1.2...v2.1.3](https://github.com/ansidev/awesome-nuxt/compare/v2.1.2...v2.1.3)

--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,6 @@ typings/
 
 # Visual Studio Code Settings
 .vscode/
+
+# OpenCode Settings
+.opencode/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,50 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org).
 
+## [v2.1.3](https://github.com/ansidev/awesome-nuxt/compare/v2.1.2...v2.1.3) (2026-08-05)
+
+### Bug Fixes
+
+- only delete PR branch and environment after merged into develop
+
+- update GitHub workflows
+
+### Code Refactoring
+
+- **github-actions:** replace the existing deploy GitHub actions with one GitHub action
+
+### Documentations
+
+- add dependency update implementation plans
+
+- require pnpm build verification in all worktrees
+
+- update dependency updates spec based on review feedback
+
+- add dependency updates design spec
+
+### Features
+
+- **github-actions:** add gitflow for GitHub actions
+
+### Dependencies
+
+| Package                             | Version                             |
+| ----------------------------------- | ----------------------------------- |
+| `@vuepress/bundler-vite`            | `^2.0.0-rc.19` `->` `^2.0.0-rc.26`  |
+| `@vuepress/client`                  | `^2.0.0-rc.19` `->` `^2.0.0-rc.26`  |
+| `@vuepress/plugin-docsearch`        | `^2.0.0-rc.67` `->` `^2.0.0-rc.125` |
+| `@vuepress/plugin-git`              | `^2.0.0-rc.66` `->` `^2.0.0-rc.125` |
+| `@vuepress/plugin-google-analytics` | `^2.0.0-rc.66` `->` `^2.0.0-rc.125` |
+| `@vuepress/plugin-pwa`              | `^2.0.0-rc.66` `->` `^2.0.0-rc.125` |
+| `@vuepress/theme-default`           | `^2.0.0-rc.66` `->` `^2.0.0-rc.125` |
+| `markdownlint-cli2`                 | `^0.16.0` `->` `^0.22.0`            |
+| `sass-embedded`                     | `^1.83.0` `->` `^1.98.0`            |
+| `vue`                               | `^3.5.13` `->` `^3.5.30`            |
+| `vuepress`                          | `^2.0.0-rc.19` `->` `^2.0.0-rc.26`  |
+
+Full Changelog: [v2.1.2...v2.1.3](https://github.com/ansidev/awesome-nuxt/compare/v2.1.2...v2.1.3)
+
 ## [v2.1.2](https://github.com/ansidev/awesome-nuxt/compare/v2.1.1...v2.1.2) (2024-12-25)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "awesome-nuxt",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "🎉 A curated list of awesome things related to Nuxt.js",
   "private": true,
   "repository": {


### PR DESCRIPTION
This PR merges the branch `release/2.1.3` back into the branch `develop`.

This ensures that the updates on the branch `release/2.1.3`, i.e. CHANGELOG and manifest updates, are also present on the branch `develop`.